### PR TITLE
add uaccess tag to devices

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -305,7 +305,7 @@ ATTR{idVendor}=="19d2", ATTR{idProduct}=="1355"
 ATTR{idVendor}=="19d2", ATTR{idProduct}=="1354", SYMLINK+="android_adb"
 
 # Enable device as a user device if found
-ENV{adb_user}=="yes", MODE="0660", GROUP="adbusers"
+ENV{adb_user}=="yes", MODE="0660", GROUP="adbusers", TAG+="uaccess"
 
 # Devices listed here {begin...end} are connected by USB
 LABEL="android_usb_rules_end"


### PR DESCRIPTION
udev automatically gives the user in the active
session permissions on all devices with the
uaccess tag (see also 70-uaccess.rules). This
means that it is not necessary anymore to be
in the adbusers group if the user is in an active
session (which should pretty much cover 99% of
all use cases).
