### PR TITLE
Added correct device ids for Nexus 4/7

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -49,13 +49,13 @@ ATTR{idVendor}=="091e", ENV{adb_user}="yes"
 ATTR{idVendor}=="18d1", ENV{adb_user}="yes"
 #		Nexus 4
 ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee2", SYMLINK+="android_adb"
-ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee2", SYMLINK+="android_fastboot"
+ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee0", SYMLINK+="android_fastboot"
 #		Nexus 7
-ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e41", SYMLINK+="android_adb"
-ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e41", SYMLINK+="android_fastboot"
+ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e42", SYMLINK+="android_adb"
+ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e40", SYMLINK+="android_fastboot"
 #		Nexus 10
-ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee1", SYMLINK+="android_adb"
-ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee1", SYMLINK+="android_fastboot"
+#ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee1", SYMLINK+="android_adb"
+#ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee1", SYMLINK+="android_fastboot"
 #		Nexus S
 ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e21"
 ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e22", SYMLINK+="android_adb"
@@ -259,12 +259,6 @@ ATTR{idVendor}=="04e8", ATTR{idProduct}=="685c"
 ATTR{idVendor}=="04e8", ATTR{idProduct}=="6860", SYMLINK+="android_adb"
 ATTR{idVendor}=="18d1", ATTR{idProduct}=="d001"
 ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e30", SYMLINK+="android_fastboot"
-#		Nexus 4
-SUBSYSTEM=="usb",ATTR{idVendor}=="18d1",ATTR{idProduct}=="4ee2",SYMLINK+="android_adb"
-SUBSYSTEM=="usb",ATTR{idVendor}=="18d1",ATTR{idProduct}=="4ee2",SYMLINK+="android_fastboot"
-#		Nexus 7
-SUBSYSTEM=="usb",ATTR{idVendor}=="18d1",ATTR{idProduct}=="4e41",SYMLINK+="android_adb"
-SUBSYSTEM=="usb",ATTR{idVendor}=="18d1",ATTR{idProduct}=="4e41",SYMLINK+="android_fastboot"
 
 
 #		Galaxy Tab 10.1, i9100 S2, i9300 S3


### PR DESCRIPTION
Google Nexus 4/7 devices change their id when you enable debugging or go into the bootloader. The id's for my Nexus 4 and 7 according to lsusb are these:

Nexus 4:
Fastboot - ID 18d1:4ee0 Google Inc.
MTP      - ID 18d1:4ee1 Google Inc. Nexus 4
MTP+ADB  - ID 18d1:4ee2 Google Inc. Nexus 4 (debug)

Nexus 7:
Fastboot - ID 18d1:4e40 Google Inc. Nexus 7 (fastboot)
MTP      - ID 18d1:4e41 Google Inc. ASUS Nexus 7 (MTP modus)
MTP+ADB  - ID 18d1:4e42 Google Inc. Nexus 7 (debug)

I hope I made the necessary changes. Also the Nexus 10 seems to have a wrong id, so I commented it out since it would be the same as for the Nexus 4 in MTP mode. Someone with the device should check. Also I deleted the entries for the Nexus 4/7 in the Samsung devices section. As far as I understand Udev (not much sadly), they are duplicates, but it should be checked by someone who understands Udev.
