### PR TITLE
Update 51-android.rules

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -266,6 +266,8 @@ ATTR{idVendor}=="04e8", ATTR{idProduct}=="685e", SYMLINK+="android_fastboot"
 ATTR{idVendor}=="04e8", ATTR{idProduct}=="6860", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
 #		Galaxy i9300 S3
 ATTR{idVendor}=="04e8", ATTR{idProduct}=="6866", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
+#   Galaxy S4 GT-I9500 Exynos Octo Core
+ATTR{idVendor}=="04e8", ATTR{idProduct}=="685d", SYMLINK+="android_adb", SUBSYSTEM=="usb", MODE="0666", GROUP="plugdev"
 
 #	Sharp
 ATTR{idVendor}=="04dd", ENV{adb_user}="yes"


### PR DESCRIPTION
Hello and thank you for maintaining this list.

I own the Intl. Samsung Galaxy S4 GT-I9500 Exynos Octo Core and was having a hard time to make it recognized within Windows so I can use Odin to root it.
The issue was that my current kernel [OS: Chakra, kernel 3.9.2-CHAKRA] detects it as 04e8:6860 while it's correct ID is 04e8:685d (I got aware of this later when rebooted the smartphone into recovery mode), once I corrected the ID I created a new rule following advice here: http://developer.android.com/tools/device.html and then I finally was able to make the Windows guest recognize it.

Note: this is my first ever contribution to a GIT project/repository, please excuse if there's anything wrong with it :/

Best regards.
