### PR TITLE
Moto G XT1033 Dual SIM

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -233,6 +233,8 @@ ATTR{idProduct}=="70a9", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 ATTR{idProduct}=="4362", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 #		Moto G
 ATTR{idProduct}=="2e76", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
+#		Moto G (Dual SIM)
+ATTR{idProduct}=="2e80", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 #		Moto G (Global GSM)
 ATTR{idProduct}=="2e82", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 GOTO="android_usb_rule_match"


### PR DESCRIPTION
This is the Dual SIM version of the Moto G identified by "ID 22b8:2e80 Motorola PCS" in lsusb.

Thanks!
