### PR TITLE
two new devices: HTC G1 and Azpen Onda tablets

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -116,6 +116,8 @@ ATTR{idProduct}=="0c91", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 ATTR{idProduct}=="0ff9"
 ATTR{idProduct}=="0ca5", SYMLINK+="android_adb"
 ATTR{idProduct}=="0fff", SYMLINK+="android_fastboot"
+#		G1
+ATTR{idProduct}=="0c01", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 #		HD2
 ATTR{idProduct}=="0c02", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 #		Hero H2000


### PR DESCRIPTION
This adds a single device: HTC G1 and a new manufacturer: Azpen Onda (http://www.azpenpc.com/)
