### PR TITLE
Add missing OnePlus One product ID : "6765"

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -302,6 +302,7 @@ ATTR{idProduct}=="9025", SYMLINK+="android_adb"
 #		OnePlus One
 ATTR{idProduct}=="6769", SYMLINK+="android_adb"
 ATTR{idProduct}=="6764", SYMLINK+="android_adb"
+ATTR{idProduct}=="6765", SYMLINK+="android_adb"
 
 #	SK Telesys
 ATTR{idVendor}=="1f53", ENV{adb_user}="yes"


### PR DESCRIPTION
Hi,
Product Id of my OnePlus One was missing, so mtp doesn't work.
I added it.
Thx to update.