### PR TITLE
added device name for HTC Sensation 0bb4:0f87

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -155,6 +155,7 @@ ATTR{idProduct}=="0c8d", SYMLINK+="android_adb"
 ATTR{idProduct}=="0c96", SYMLINK+="android_adb"
 #		One (m7) && One (m8)
 ATTR{idProduct}=="0c93"
+#		Sensation
 ATTR{idProduct}=="0f87", SYMLINK+="android_adb"
 ATTR{idProduct}=="0ff0", SYMLINK+="android_fastboot"
 #		One V


### PR DESCRIPTION
USB ID `0bb4:0f87` already exists in `51-android.rules`. Simply added the device name `Sensation`. 