### PR TITLE
Add rule for Sony Ericsson Xperia Z3 Compact.

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -385,6 +385,8 @@ ATTR{idProduct}=="0186", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 ATTR{idProduct}=="5176", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 #		Xperia Z1 Compact
 ATTR{idProduct}=="51a7", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
+#		Xperia Z3 Compact
+ATTR{idProduct}=="01bb", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 GOTO="android_usb_rule_match"
 LABEL="not_Sony_Ericsson"
 


### PR DESCRIPTION
The device shows up as

    Bus 002 Device 002: ID 0fce:01bb Sony Ericsson Mobile Communications AB D5803 [Xperia Z3 Compact] (MTP mode)

in `lsusb` output.