### PR TITLE
added text string for Samsung Galaxy S3 SHW-M440S Korean version

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -333,6 +333,7 @@ ATTR{idProduct}=="689e", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 ATTR{idProduct}=="6877", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
 #		Galaxy Nexus (GSM)
 ATTR{idProduct}=="685c"
+#		Galaxy S3 SHW-M440S 3G (Korea only)
 ATTR{idProduct}=="6860", SYMLINK+="android_adb"
 #		Galaxy Core, Tab 10.1, i9100 S2, i9300 S3, N5100 Note (8.0)
 ATTR{idProduct}=="6860"


### PR DESCRIPTION
I use the SGS3 SHW-M440S which is a 3G version only sold in South Korea. I have added a comment line above the relevant USB ID in `51-android.rules`.