### PR TITLE
Add Micromax P702

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -244,6 +244,14 @@ ATTR{idProduct}=="61f9", SYMLINK+="android_adb"
 GOTO="android_usb_rule_match"
 LABEL="not_LG"
 
+#	Micromax
+ATTR{idVendor}!="2a96", GOTO="not_Micromax"
+ENV{adb_user}="yes"
+#		P702
+ATTR{idProduct}=="201d", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
+GOTO="android_usb_rule_match"
+LABEL="not_Micromax"
+
 #	Motorola
 ATTR{idVendor}!="22b8", GOTO="not_Motorola"
 ENV{adb_user}="yes"

--- a/ubuntu/51-android.rules
+++ b/ubuntu/51-android.rules
@@ -51,6 +51,9 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="17ef", MODE="0666", GROUP="plugdev"
 ## LG
 SUBSYSTEM=="usb", ATTR{idVendor}=="1004", MODE="0666", GROUP="plugdev" 
 
+## Micromax
+SUBSYSTEM=="usb", ATTR{idVendor}=="2a96", MODE="0666", GROUP="plugdev" 
+
 ## Motorola
 SUBSYSTEM=="usb", ATTR{idVendor}=="22b8", MODE="0666", GROUP="plugdev" 
 


### PR DESCRIPTION
Hi, I've got another one for you :).

Proof: https://dl.dropboxusercontent.com/u/93551/2016-04-08%2017.12.20.jpg

I've added the VendorId to the ubuntu file too. BTW, there's dangling whitespace there, I just followed the convention ;).

I've got another Micromax device (phone) that does not use that VendorId but one of the Google ones `18d1:d002`. Looks like they finally bothered to buy an ID.