### PR TITLE
Add HUAWEI MediaPad M2-A01L

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -193,6 +193,8 @@ ATTR{idProduct}=="1021", ENV{adb_adbfast}="yes"
 ATTR{idProduct}=="1057", SYMLINK+="android_adb"
 #		HiKey usbnet
 ATTR{idProduct}=="1050", SYMLINK+="android_adb"
+#		MediaPad M2-A01L
+ATTR{idProduct}=="1052", SYMLINK+="android_adb"
 GOTO="android_usb_rule_match"
 LABEL="not_Huawei"
 


### PR DESCRIPTION
Proof: https://dl.dropboxusercontent.com/u/93551/2016-04-22%2013.01.58.jpg

Had to [root](http://forum.xda-developers.com/mediapad-m2/how-to/guide-unlock-bootlader-twrp-root-huawei-t3322340) that thing.

Feels like a cheap 3rd gen iPad but with lower DPI.

I don't get why Android tablets assume that I would use them horizontally.