### PR TITLE
Added rule for amazon fire tablet 7inch

### DIFF
--- a/ubuntu/51-android.rules
+++ b/ubuntu/51-android.rules
@@ -3,6 +3,9 @@
 ## Acer
 SUBSYSTEM=="usb", ATTR{idVendor}=="0502", MODE="0666", GROUP="plugdev"
 
+## Amazon
+SUBSYSTEM=="usb", ATTR{idVendor}=="1949", MODE="0666", GROUP="plugdev"
+
 ## ASUS
 SUBSYSTEM=="usb", ATTR{idVendor}=="0b05", MODE="0666", GROUP="plugdev"
 


### PR DESCRIPTION
I guess the idVendor could be the same for all fire tablets. I only tested it with the new ($50) amazon fire tablet.