### PR TITLE
OnePlus 3

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -348,6 +348,8 @@ ATTR{idProduct}=="9025", SYMLINK+="android_adb"
 ATTR{idProduct}=="676?", SYMLINK+="android_adb"
 #		OnePlus Two
 ATTR{idProduct}=="9011", SYMLINK+="android_adb"
+#		OnePlus 3
+ATTR{idProduct}=="900e", SYMLINK+="android_adb"
 GOTO="android_usb_rule_match"
 LABEL="not_Qualcomm"
 

--- a/51-android.rules
+++ b/51-android.rules
@@ -119,8 +119,8 @@ ATTR{idProduct}=="0fff", SYMLINK+="android_fastboot"
 ATTR{idProduct}=="d00d", SYMLINK+="android_fastboot"
 #		Include: Samsung Galaxy Nexus (GSM)
 ATTR{idProduct}=="4e30", SYMLINK+="android_fastboot"
-#		Recovery adb entry for Nexus Family
-ATTR{idProduct}=="d001", SYMLINK+="android_adb"
+#		Recovery adb entry for Nexus Family (orig d001, OP3 has 18d1:d002)
+ATTR{idProduct}=="d00?", SYMLINK+="android_adb"
 GOTO="android_usb_rule_match"
 LABEL="not_Google"
 


### PR DESCRIPTION
ID taken from https://forum.xda-developers.com/oneplus-3/how-to/guide-connect-op3-mtp-linux-ubuntu-t3402472

Update to recovery entry for the Nexus Family based on a lsusb from a friend owning a OP3:

    Bus 001 Device 014: ID 18d1:d002 Google Inc. Nexus 4 (debug)