### PR TITLE
Added Sony Xperia Z2

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -431,6 +431,8 @@ ATTR{idProduct}=="0186", ENV{adb_adbfast}="yes"
 ATTR{idProduct}=="5176", ENV{adb_adbfast}="yes"
 #		Xperia Z1 Compact
 ATTR{idProduct}=="51a7", ENV{adb_adbfast}="yes"
+#		Xperia Z2
+ATTR{idProduct}=="01af", ENV{adb_adbfast}="yes"
 #		Xperia Z3 Compact
 ATTR{idProduct}=="01bb", ENV{adb_adbfast}="yes"
 #		Xperia Z3+ Dual


### PR DESCRIPTION
Based on model D6503

mtp user access worked after this change. I haven't tested the adb stuff yet. (so I'm not sure if adb_adbfast is correct)