### PR TITLE
Readme: Fix repo cloning for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ On Arch it should be enough to follow the [instructions for connecting a device 
 ### Ubuntu
 
     # Clone this repository
-    git clone git@github.com:M0Rf30/android-udev-rules.git
+    git clone https://github.com/M0Rf30/android-udev-rules.git
     # Create a sym-link to the rules file
     sudo cp android-udev-rules/51-android.rules /etc/udev/rules.d/
     # Change file permissions


### PR DESCRIPTION
Currently the ubuntu steps listed to clone using git.
This method causes authentication errors when realistically is not necessary for average user
Just use the link provided from clicking the 'clone or download' link.