### PR TITLE
Update 51-android.rules

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -375,6 +375,9 @@ ATTR{idVendor}=="1d4d", ENV{adb_user}="yes"
 #	Philips
 ATTR{idVendor}=="0471", ENV{adb_user}="yes"
 
+# Pico i.MX7 Dual Development Board
+SUBSYSTEM=="usb", ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee7", MODE="0660", GROUP="plugdev", SYMLINK+="android%n"%
+
 #	PMC-Sierra
 ATTR{idVendor}=="04da", ENV{adb_user}="yes"
 


### PR DESCRIPTION
adds the Pico i.MX7 Dual Development Board
all fame goes to @johnjohndoe
https://gist.github.com/johnjohndoe/a67d1558d01cb79bf6347beb35722ece