### PR TITLE
Ubuntu instructions - minor consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ On Arch it should be enough to follow the [instructions for connecting a device 
 
     # Clone this repository
     git clone https://github.com/M0Rf30/android-udev-rules.git
+    cd android-udev-rules
     # Copy rules file
-    sudo cp -v ./android-udev-rules/51-android.rules /etc/udev/rules.d/51-android.rules
-    # OR oreate a sym-link to the rules file - choose this option if you'd like to update your udev rules using git.
-    sudo ln -sf $PWD/android-udev-rules/51-android.rules /etc/udev/rules.d/51-android.rules
+    sudo cp -v 51-android.rules /etc/udev/rules.d/51-android.rules
+    # OR create a sym-link to the rules file - choose this option if you'd like to update your udev rules using git.
+    sudo ln -sf 51-android.rules /etc/udev/rules.d/51-android.rules
     # Change file permissions
     sudo chmod a+r /etc/udev/rules.d/51-android.rules
     # If adbusers group already exists remove old adbusers group
     groupdel adbusers
     # add the adbusers group if it's doesn't already exist
-    sudo cp android-udev.conf to /usr/lib/sysusers.d/
+    sudo mkdir -p /usr/lib/sysusers.d/ && sudo cp android-udev.conf /usr/lib/sysusers.d/
     sudo systemd-sysusers
     # Add your user to the adbusers group
     sudo usermod -a -G adbusers $(whoami)


### PR DESCRIPTION
Hi it's a minor README change, please have a look - 

Ubuntu instructions - some commands were using `$PWD` while some were already inside the directory -  made the instructions consistent for copy-paste ease

Added a `mkdir` which should address the problem raised [here](https://github.com/M0Rf30/android-udev-rules/commit/da35e0345cfe50e45dcc6c8d6d841c71117cf899#commitcomment-26559262).  I had the same issue where the sysusers.d directory didn't exist.