### PR TITLE
William Swiss: added line under the Motorola section for the Moto x4

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -361,6 +361,8 @@ ATTR{idProduct}=="2e76", ENV{adb_adbfast}="yes"
 ATTR{idProduct}=="2e80", ENV{adb_adbfast}="yes"
 #		Moto E/G (Global GSM)
 ATTR{idProduct}=="2e82", ENV{adb_adbfast}="yes"
+#		Moto x4
+ATTR{idProduct}=="2e81", ENV{adb_adbfast}="yes"
 #		Droid Turbo 2) 
 ATTR{idProduct}=="2ea4", ENV{adb_adbfast}="yes", SYMLINK+="android%n"
 GOTO="android_usb_rule_match"


### PR DESCRIPTION
I noticed with my new Moto x4 that it was not connecting properly via adb. Thankfully, I found [http://www.janosgyerik.com/adding-udev-rules-for-usb-debugging-android-devices/](Adding udev rules for Android) and have successfully backed up the phone and used the bootloader activation using adb.