### PR TITLE
Essential Phone PH-1 is also known as `2e17:c032`

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -110,7 +110,7 @@ ATTR{idVendor}!="2e17", GOTO="not_Essential"
 ENV{adb_user}="yes"
 #		Essential PH-1
 ATTR{idProduct}=="c009", SYMLINK+="android_adb"
-ATTR{idProduct}=="c030", SYMLINK+="android_adb"
+ATTR{idProduct}=="c03[02]", SYMLINK+="android_adb"
 GOTO="android_usb_rule_match"
 LABEL="not_Essential"
 


### PR DESCRIPTION
Hi. My Essential Phone is labeled as `2e17:c032` ([and I’m not the only one](//forum.xda-developers.com/essential-phone/help/fastboot-commands-t3950106)).

Variant: Telus

The syntax should be ok, but please verify.

PS: Just ignore the comment on the commit, it’s not actually a fix