### PR TITLE
Removed duplicate entry for Qualcomm (05c6)

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -600,9 +600,6 @@ ATTR{idVendor}=="0451", ATTR{idProduct}=="d010", ENV{adb_user}="yes"
 #	Toshiba
 ATTR{idVendor}=="0930", ENV{adb_user}="yes"
 
-#	WEARNERS
-ATTR{idVendor}=="05c6", ENV{adb_user}="yes"
-
 #	XiaoMi
 ATTR{idVendor}!="2717", GOTO="not_XiaoMi"
 ENV{adb_user}="yes"


### PR DESCRIPTION
Line 458-460 are already taking care of this:

 458 # Qualcomm
 459 ATTR{idVendor}!="05c6", GOTO="not_Qualcomm"
 460 ENV{adb_user}="yes"

Test: adb device with pid 05c6 still working