### PR TITLE
Adds support for Huawei P10 Lite to udev rules

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -266,6 +266,8 @@ ATTR{idProduct}=="1051", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_ME
 ATTR{idProduct}=="1052", SYMLINK+="android_adb"
 #		MediaPad T3
 ATTR{idProduct}=="107d", SYMLINK+="android_adb"
+#       P10 Lite
+ATTR{idProduct}=="107e", SYMLINK+="android_adb"
 #		Watch
 ATTR{idProduct}=="1c2c", SYMLINK+="android_adb"
 #		Mate 9


### PR DESCRIPTION
Hi,

This adds support to Huawei P10 Lite to udev rules.
`Bus 001 Device 016: ID 12d1:107e Huawei Technologies Co., Ltd. WAS-LX1A`
Correct me if I lack anything here.

Thanks