### PR TITLE
nvidia corrected to 0955, should close issue #163

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -409,10 +409,14 @@ ATTR{idVendor}=="2e04", ENV{adb_user}="yes"
 ATTR{idVendor}=="2080", ENV{adb_user}="yes"
 
 #	Nvidia
-ATTR{idVendor}!="0995", GOTO="not_Nvidia"
+ATTR{idVendor}!="0955", GOTO="not_Nvidia"
 ENV{adb_user}="yes"
 #		Audi SDIS Rear Seat Entertainment Tablet
+#		Folio
 ATTR{idProduct}=="7000", SYMLINK+="android_fastboot"
+ATTR{idProduct}=="7100", ENV{adb_user}="yes"
+#		SHIELD Tablet (debug)
+ATTR{idProduct}=="CF05", SYMLINK+="android_adb"
 #		Shield TV
 ATTR{idProduct}=="b442", SYMLINK+="android_fastboot"
 GOTO="android_usb_rule_match"


### PR DESCRIPTION
Reading through issue #163, noted that the vendor ID seen is 0955, and not 0995.
Also note that some digging shows 0955:7000 is also a Toshiba Folio.
It may be probable that the nvidia chip used here was used in more than one product.

Checking internet, found two references to Nvidia, 0955:7000 for fastboot
and another that mentions 0955:7100 which presumably is another mode but not described (therefore assuming maybe a user or development mode).

Squash merge is ok.
