### PR TITLE
Skip hubs and printers. avoid assuming android developer mode

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -131,41 +131,39 @@ ATTR{idVendor}=="091e", ENV{adb_user}="yes"
 
 #	Google
 ATTR{idVendor}!="18d1", GOTO="not_Google"
-ENV{adb_user}="yes"
 #		Nexus, Pixel, Pixel XL, Pixel 2, Pixel 2XL (4ee2=mtp,adb 4ee4=rndis,adb 4ee6=ptp,adb 4ee7=adb 4ee9=midi,adb 2d01=accessory,adb 2d03=audio_source,adb 2d05=accessory,audio_source,adb)
 #		See https://android.googlesource.com/device/google/wahoo/+/master/init.hardware.usb.rc
-ATTR{idProduct}=="4ee2", SYMLINK+="android_adb"
-ATTR{idProduct}=="4ee4", SYMLINK+="android_adb"
-ATTR{idProduct}=="4ee6", SYMLINK+="android_adb"
-ATTR{idProduct}=="4ee7", SYMLINK+="android_adb"
-ATTR{idProduct}=="4ee9", SYMLINK+="android_adb"
-ATTR{idProduct}=="2d01", SYMLINK+="android_adb"
-ATTR{idProduct}=="2d03", SYMLINK+="android_adb"
-ATTR{idProduct}=="2d05", SYMLINK+="android_adb"
-ATTR{idProduct}=="4ee0", SYMLINK+="android_fastboot"
+#		OnePlus 6, 4ee1=charging, 4ee2=MTP+debug, 4ee6=PTP+debug, 4ee7=charging+debug
+# 		Pico i.MX7 Dual Development Board 4ee7=debug
+ATTR{idProduct}=="4ee0", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="4ee2", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee4", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee6", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee9", ENV{adb_adb}="yes"
+
+ATTR{idProduct}=="2d01", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2d03", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2d05", ENV{adb_adb}="yes"
 #		Nexus 7
-ATTR{idProduct}=="4e42", SYMLINK+="android_adb"
-ATTR{idProduct}=="4e40", SYMLINK+="android_fastboot"
+ATTR{idProduct}=="4e42", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4e40", ENV{adb_adbfast}="yes"
 #		Nexus 5, Nexus 10
 ATTR{idProduct}=="4ee1", ENV{adb_adbfast}="yes"
 #		Nexus S (4e22=mass_storage,adb 4e24=rndis,adb)
 #		See https://android.googlesource.com/device/samsung/crespo/+/android-4.1.2_r2.1/init.herring.usb.rc
-ATTR{idProduct}=="4e22", SYMLINK+="android_adb"
-ATTR{idProduct}=="4e24", SYMLINK+="android_adb"
-ATTR{idProduct}=="4e20", SYMLINK+="android_fastboot"
-#		Galaxy Nexus
+ATTR{idProduct}=="4e22", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4e24", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4e20", ENV{adb_adbfast}="yes"
+#		Galaxy Nexus, Galaxy Nexus (GSM)
 ATTR{idProduct}=="4e30", ENV{adb_adbfast}="yes"
 #		Nexus One (4e11=normal,4e12=debug,0fff=debug)
-ATTR{idProduct}=="4e12", SYMLINK+="android_adb"
-ATTR{idProduct}=="0fff", SYMLINK+="android_fastboot"
-#		Generic and unspecified debug interface
-ATTR{idProduct}=="d00d", SYMLINK+="android_fastboot"
-# 		Pico i.MX7 Dual Development Board
-ATTR{idProduct}=="4ee7", SYMLINK+="android_adb"
-#		Include: Samsung Galaxy Nexus (GSM)
-ATTR{idProduct}=="4e30", SYMLINK+="android_fastboot"
+ATTR{idProduct}=="4e12", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0fff", ENV{adb_adbfast}="yes"
 #		Recovery adb entry for Nexus Family (orig d001, OP3 has 18d1:d002)
-ATTR{idProduct}=="d00?", SYMLINK+="android_adb"
+ATTR{idProduct}=="d00?", ENV{adb_adb}="yes"
+#		Generic and unspecified debug interface (test after d00?)
+ATTR{idProduct}=="d00d", ENV{adb_adbfast}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Google"
 
@@ -423,13 +421,14 @@ ATTR{idVendor}=="2833", ENV{adb_user}="yes"
 
 #	OnePlus(Oreo)
 ATTR{idVendor}!="2a70", GOTO="not_OnePlus"
-ENV{adb_user}="yes"
-#		Charging mode
-ATTR{idProduct}=="4ee7", SYMLINK+="android_adb"
+#		OnePlus 6, 4ee1=charging, 4ee2=MTP+debug, 4ee6=PTP+debug, 4ee7=charging+debug
+ATTR{idProduct}=="4ee2", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee6", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
 #		MTP mode
-ATTR{idProduct}=="9011", SYMLINK+="android_adb"
+ATTR{idProduct}=="9011", ENV{adb_adb}="yes"
 #		PTP mode
-ATTR{idProduct}=="904e", SYMLINK+="android_adb"
+ATTR{idProduct}=="904e", ENV{adb_adb}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_OnePlus"
 

--- a/51-android.rules
+++ b/51-android.rules
@@ -15,9 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-# Skip this section below if this device is not connected by USB
+# Skip section below if device not add, usb, or is a hub or printer
 ACTION!="add", GOTO="android_usb_rules_end"
 SUBSYSTEM!="usb", GOTO="android_usb_rules_end"
+ATTR{bDeviceClass}=="09", GOTO="android_usb_rules_end"
+ENV{ID_USB_INTERFACES}=="*:0701??:*", GOTO="android_usb_rules_end"
 
 # This is the universal rule suggested here:
 # http://ktnr74.blogspot.com/2013/04/universal-udev-rule-for-all-android.html
@@ -30,13 +32,12 @@ LABEL="android_usb_rules_begin"
 # Devices listed here in android_usb_rules_{begin...end} are connected by USB
 #	Acer
 ATTR{idVendor}!="0502", GOTO="not_Acer"
-ENV{adb_user}="yes"
 #		Iconia Tab A1-830
 ATTR{idProduct}=="3604", ENV{adb_adbfast}="yes"
 #		Iconia Tab A500
 ATTR{idProduct}=="3325", ENV{adb_adbfast}="yes"
 #		Liquid (3202=normal,3203=debug)
-ATTR{idProduct}=="3203", SYMLINK+="android_adb"
+ATTR{idProduct}=="3203", ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Acer"
 
@@ -54,7 +55,6 @@ ATTR{idVendor}=="1949", ATTR{idProduct}=="0006", ENV{adb_adbfast}="yes"
 
 #	Archos
 ATTR{idVendor}!="0e79", GOTO="not_Archos"
-ENV{adb_user}="yes"
 #		43
 ATTR{idProduct}=="1417", ENV{adb_adbfast}="yes"
 #		101
@@ -93,7 +93,6 @@ ATTR{idVendor}=="1f3a", ENV{adb_user}="yes"
 
 #	BQ
 ATTR{idVendor}!="2a47", GOTO="not_BQ"
-ENV{adb_user}="yes"
 #		Aquaris 4.5
 ATTR{idProduct}=="0c02", ENV{adb_adbfast}="yes"
 ATTR{idProduct}=="2008", ENV{adb_adbfast}="yes"
@@ -105,10 +104,9 @@ LABEL="not_BQ"
 
 #	Essential
 ATTR{idVendor}!="2e17", GOTO="not_Essential"
-ENV{adb_user}="yes"
 #		Essential PH-1
-ATTR{idProduct}=="c009", SYMLINK+="android_adb"
-ATTR{idProduct}=="c03[02]", SYMLINK+="android_adb"
+ATTR{idProduct}=="c009", ENV{adb_adb}=="yes"
+ATTR{idProduct}=="c03[02]", ENV{adb_adb}=="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Essential"
 
@@ -179,9 +177,8 @@ ATTR{idVendor}=="109b", ENV{adb_user}="yes"
 
 #	Honeywell/Foxconn
 ATTR{idVendor}!="0c2e", GOTO="not_Honeywell"
-ENV{adb_user}="yes"
 #		D70e
-ATTR{idProduct}=="0ba3", SYMLINK+="android_adb"
+ATTR{idProduct}=="0ba3", ENV{adb_adb}=="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Honeywell"
 
@@ -282,9 +279,8 @@ LABEL="not_Intel"
 
 #	IUNI
 ATTR{idVendor}!="271d", GOTO="not_IUNI"
-ENV{adb_user}="yes"
 #		U3
-ATTR{idProduct}=="bf39", SYMLINK+="android_adb"
+ATTR{idProduct}=="bf39", ENV{adb_adb}=="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_IUNI"
 
@@ -341,25 +337,22 @@ LABEL="not_LG"
 
 #       Idea
 ATTR{idVendor}!="18d1", GOTO="not_IDEA"
-ENV{adb_user}="yes"
 #       XDS-1078
-ATTR{idProduct}=="2c11", SYMLINK="android_adb"
+ATTR{idProduct}=="2c11", ENV{adb_adb}=="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_IDEA"
 
 #	Meizu
 ATTR{idVendor}!="2a45", GOTO="not_Meizu"
-ENV{adb_user}="yes"
 #		MX6
-ATTR{idProduct}=="0c02", SYMLINK+="android_adb"
+ATTR{idProduct}=="0c02", ENV{adb_adb}=="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Meizu"
 
 #	Micromax
 ATTR{idVendor}!="2a96", GOTO="not_Micromax"
-ENV{adb_user}="yes"
 #		P702
-ATTR{idProduct}=="201d", SYMLINK+="android_adb", SYMLINK+="android_fastboot"
+ATTR{idProduct}=="201d", ENV{adb_adbfast}=="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Micromax"
 
@@ -442,7 +435,6 @@ LABEL="not_OnePlus"
 
 #	Oppo
 ATTR{idVendor}!="22d9", GOTO="not_Oppo"
-ENV{adb_adbuser}="yes"
 #		Find 5 (2767=debug)
 ATTR{idProduct}=="2767", ENV{adb_adb}="yes"
 ATTR{idProduct}=="2764", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
@@ -496,7 +488,6 @@ LABEL="not_Qualcomm"
 
 #	Research In Motion, Ltd.
 ATTR{idVendor}!="0fca", GOTO="not_RIM"
-ENV{adb_user}="yes"
 #		BlackBerry DTEK60
 ATTR{idProduct}=="8042", ENV{adb_fastboot}="yes"
 GOTO="android_usb_rule_match"
@@ -664,7 +655,6 @@ ATTR{idVendor}=="1ebf", ENV{adb_user}="yes"
 
 #	Zebra
 ATTR{idVendor}!="05e0", GOTO="not_Zebra"
-ENV{adb_user}="yes"
 #		TC55
 ATTR{idProduct}=="2101", ENV{adb_adb}="yes"
 GOTO="android_usb_rule_match"
@@ -672,11 +662,10 @@ LABEL="not_Zebra"
 
 #	ZTE
 ATTR{idVendor}!="19d2", GOTO="not_ZTE"
-ENV{adb_user}="yes"
 #		Blade (1353=normal,1351=debug)
-ATTR{idProduct}=="1351", SYMLINK+="android_adb"
+ATTR{idProduct}=="1351", ENV{adb_adb}="yes"
 #		Blade S (Crescent, Orange San Francisco 2) (1355=normal,1354=debug)
-ATTR{idProduct}=="1354", SYMLINK+="android_adb"
+ATTR{idProduct}=="1354", ENV{adb_adb}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_ZTE"
 

--- a/51-android.rules
+++ b/51-android.rules
@@ -15,18 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-# Skip section below if device not add, usb, or is a hub or printer
+# Skip testing for android devices if device is not add, or usb
 ACTION!="add", GOTO="android_usb_rules_end"
 SUBSYSTEM!="usb", GOTO="android_usb_rules_end"
-ATTR{bDeviceClass}=="09", GOTO="android_usb_rules_end"
-ENV{ID_USB_INTERFACES}=="*:0701??:*", GOTO="android_usb_rules_end"
 
-# This is the universal rule suggested here:
+# For Android devices that enable this universal rule suggested here:
 # http://ktnr74.blogspot.com/2013/04/universal-udev-rule-for-all-android.html
 # Commented as a reminder (we prefer a punctual device detection)
-# LABEL="android_universal_rule"
-# ENV{ID_USB_INTERFACES}!="*:ff420?:*", GOTO="android_usb_rules_begin"
-# ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{ID_USB_INTERFACES}=="*:ff420?:*", MODE="0660", GROUP="adbusers", SYMLINK+="android/$env{ID_SERIAL_SHORT}"
+# ENV{ID_USB_INTERFACES}=="*:ff420?:*", SYMLINK+="android/$env{ID_SERIAL_SHORT}", GOTO="android_usb_rule_match"
+
+# Skip testing for unexpected devices like hubs or printers
+ATTR{bDeviceClass}=="09", GOTO="android_usb_rules_end"
+ENV{ID_USB_INTERFACES}=="*:0701??:*", ENV{adb_adb}="yes", GOTO="android_usb_rules_end"
 
 LABEL="android_usb_rules_begin"
 # Devices listed here in android_usb_rules_{begin...end} are connected by USB


### PR DESCRIPTION
Some devices aren't likely going to ever be android devices
such as hubs or printers, therefore skip tests and move on.

Removed default ENV{adb_user}="yes" for several vendors and
set yes only if matches vendor and product-mode. These need
to be tested-out, therefore just change some for now, later
change the rest. ...android.rules should check for android,
and leave mtp mode for another set of rules devoted to mtp.

also relates to issue #164

squash merge okay.
