### PR TITLE
Add Zebra TC72 support

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -700,6 +700,8 @@ ATTR{idVendor}=="1ebf", ENV{adb_user}="yes"
 ATTR{idVendor}!="05e0", GOTO="not_Zebra"
 #		TC55
 ATTR{idProduct}=="2101", ENV{adb_adb}="yes"
+#		TC72
+ATTR{idProduct}=="2106", ENV{adb_adb}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Zebra"
 


### PR DESCRIPTION
This is how the [Zebra TC72](https://www.zebra.com/us/en/products/mobile-computers/handheld/tc72-tc77-series-touch-computer.html) appears from `lsusb`:
```
Bus 001 Device 021: ID 05e0:2106 Symbol Technologies
```

With this new rule installed, I'm able to use the TC72 with Android Studio.