### PR TITLE
Add a rule for Microsoft Surface Duo

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -367,6 +367,10 @@ ATTR{idProduct}=="201d", ENV{adb_adbfast}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Micromax"
 
+#	Microsoft
+#		Surface Duo
+SUBSYSTEM=="usb", ATTR{idVendor}=="045e", ATTR{idProduct}=="0c26", ENV{adb_user}="yes"
+
 #	Motorola
 ATTR{idVendor}!="22b8", GOTO="not_Motorola"
 ENV{adb_user}="yes"


### PR DESCRIPTION
Here's the output of `lsusb`:

```
Bus 001 Device 024: ID 045e:0c26 Microsoft Corp. Surface Duo
```

With this change I am able to use the device over adb
