### PR TITLE
Add Iconia Tab 210 (ref #204)

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -34,6 +34,8 @@ LABEL="android_usb_rules_begin"
 ATTR{idVendor}!="0502", GOTO="not_Acer"
 #		Iconia Tab A1-830
 ATTR{idProduct}=="3604", ENV{adb_adbfast}="yes"
+#		Iconia Tab A210 (33cc=normal,33cb=debug)
+ATTR{idProduct}=="33cb", ENV{adb_adb}="yes"
 #		Iconia Tab A500
 ATTR{idProduct}=="3325", ENV{adb_adbfast}="yes"
 #		Liquid (3202=normal,3203=debug)
@@ -177,6 +179,10 @@ ATTR{idProduct}=="0fff", ENV{adb_adbfast}="yes"
 ATTR{idProduct}=="d00?", ENV{adb_adb}="yes"
 #		Generic and unspecified debug interface (test after d00?)
 ATTR{idProduct}=="d00d", ENV{adb_adbfast}="yes"
+
+#	Other vendors that also used duplicated Google's idVendor code follows:
+#	IDEA XDS-1078 (debug=2c11)
+ATTR{idProduct}=="2c11", ENV{adb_adb}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Google"
 
@@ -345,13 +351,6 @@ ATTR{idProduct}=="61f9", SYMLINK+="android_adb"
 ATTR{idProduct}=="6300", SYMLINK+="android_adb"
 GOTO="android_usb_rule_match"
 LABEL="not_LG"
-
-#       Idea
-ATTR{idVendor}!="18d1", GOTO="not_IDEA"
-#       XDS-1078
-ATTR{idProduct}=="2c11", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
-LABEL="not_IDEA"
 
 #	Meizu
 ATTR{idVendor}!="2a45", GOTO="not_Meizu"
@@ -739,7 +738,7 @@ ENV{adb_adb}=="yes", ENV{adb_user}="yes", SYMLINK+="android_adb"
 ENV{adb_fast}=="yes", SYMLINK+="android_fastboot"
 
 # Enable device as a user device if found (add an "android" SYMLINK)
-ENV{adb_user}=="yes", MODE="0660", GROUP="adbusers", TAG+="uaccess", SYMLINK+="android"
+ENV{adb_user}=="yes", MODE="0660", GROUP="adbusers", TAG+="uaccess", SYMLINK+="android", SYMLINK+="android%n"
 
 # Devices listed here {begin...end} are connected by USB
 LABEL="android_usb_rules_end"


### PR DESCRIPTION
1 - The Tab 210 was mentioned but wasn't added yet. Including it here.
2 - Also add multiple phone pointers with another symlink to /dev/android%n based on Motorola pointer.
3 - There is one Idea phone that used the same idVendor as Google. Best to move it where it can actually be seen and recognized.