### PR TITLE
fix MediaTek rules

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -413,7 +413,7 @@ GOTO="android_usb_rule_match"
 LABEL="not_Motorola"
 
 #	MTK (MediaTek Inc)
-ATTR{idVendor}=="0e8d", GOTO="not_MTK"
+ATTR{idVendor}!="0e8d", GOTO="not_MTK"
 ENV{adb_user}="yes"
 #       Umidigi F1
 ATTR{idProduct}=="201c", ENV{adb_adbfast}="yes"


### PR DESCRIPTION
It looks like a typo in the rules for MediaTek.
It was preventing my Umidigi A3 (0e8d:201c) from being detected.
I tested the changed rules and it now registers properly.