### PR TITLE
Add ZTE P685M LTE Cat4 modem

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -732,6 +732,8 @@ ATTR{idVendor}!="19d2", GOTO="not_ZTE"
 ATTR{idProduct}=="1351", ENV{adb_adb}="yes"
 #		Blade S (Crescent, Orange San Francisco 2) (1355=normal,1354=debug)
 ATTR{idProduct}=="1354", ENV{adb_adb}="yes"
+#		P685M LTE modem
+ATTR{idProduct}=="1275", ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_ZTE"
 


### PR DESCRIPTION
This modem is used in ZTE MF283+ router and exposes usable ADB
interface. Modem is also usable as a standalone MiniCard device.

Ref: https://github.com/openwrt/openwrt/pull/3841