### PR TITLE
Add Android accessory mode

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -148,7 +148,7 @@ ATTR{idVendor}=="091e", ENV{adb_user}="yes"
 
 #	Google
 ATTR{idVendor}!="18d1", GOTO="not_Google"
-#		Nexus, Pixel, Pixel XL, Pixel 2, Pixel 2XL (4ee1=mtp, 4ee2=mtp,adb 4ee3=rndis, 4ee4=rndis,adb 4ee5=ptp, 4ee6=ptp,adb 4ee7=adb 4ee8=midi, 4ee9=midi,adb 2d01=accessory,adb 2d03=audio_source,adb 2d05=accessory,audio_source,adb)
+#		Nexus, Pixel, Pixel XL, Pixel 2, Pixel 2XL (4ee1=mtp, 4ee2=mtp,adb 4ee3=rndis, 4ee4=rndis,adb 4ee5=ptp, 4ee6=ptp,adb 4ee7=adb 4ee8=midi, 4ee9=midi,adb 2d00=accessory 2d01=accessory,adb 2d03=audio_source,adb 2d05=accessory,audio_source,adb)
 #		See https://android.googlesource.com/device/google/wahoo/+/master/init.hardware.usb.rc
 #		OnePlus 6, 4ee1=charging, 4ee2=MTP+debug, 4ee6=PTP+debug, 4ee7=charging+debug
 #		Pico i.MX7 Dual Development Board 4ee7=debug
@@ -165,6 +165,7 @@ ATTR{idProduct}=="5201", ENV{adb_fast}="yes"
 ATTR{idProduct}=="5203", ENV{adb_adb}="yes"
 ATTR{idProduct}=="5208", ENV{adb_adb}="yes"
 
+ATTR{idProduct}=="2d00", ENV{adb_adb}="yes"
 ATTR{idProduct}=="2d01", ENV{adb_adb}="yes"
 ATTR{idProduct}=="2d03", ENV{adb_adb}="yes"
 ATTR{idProduct}=="2d05", ENV{adb_adb}="yes"


### PR DESCRIPTION
As seen in [0], the accessory mode uses the 2d00 id.

Access to this configuration is needed for Android Open Accessory[1],
specifically for WebAOA[2] which allows users to control a connected
device via this protocol.

[0] https://cs.android.com/android/platform/superproject/+/2aa85be00e485a06fb5a86276a2344ef1182e2af:system/core/rootdir/init.usb.rc;l=49-56
[1] https://source.android.com/devices/accessories/protocol
[2] https://source.android.com/compatibility/tests/development/android-test-station/ats-user-builds