### PR TITLE
Add Razer Phone 2 ADB mode

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -542,6 +542,7 @@ LABEL="not_Qualcomm"
 ATTR{idVendor}!="1532", GOTO="not_Razer"
 #		Razer Phone 2
 ATTR{idProduct}=="9050", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="9051", ENV{adb_adb}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Razer"
 


### PR DESCRIPTION
### Preface

> Hey, but didn't you do this already in #199?

No! I only added fastboot support as it was the only thing I needed at the time. I was working on a non-android Linux on the phone, and didn't use the phone in a way that involved ADB.

### What I did

Still using NixOS Linux

**Before**:

```
~ $ adb shell
adb: insufficient permissions for device
See [http://developer.android.com/tools/device.html] for more information
```

**After**:

```
~ $ adb shell echo ok!
ok!
```