### PR TITLE
Add Yongnuo YN450M

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -530,6 +530,8 @@ ATTR{idProduct}=="90bb", ENV{adb_adb}="yes"
 ATTR{idProduct}=="9011", SYMLINK+="android_adb"
 #		OnePlus 6 / Asia
 ATTR{idProduct}=="f003", SYMLINK+="android_adb"
+#   Yongnuo YN450m (identified in lsusb as Intex Aqua Fish & Jolla C Diagnostic Mode)
+ATTR{idProduct}=="9091", SYMLINK+="android_adb"
 GOTO="android_usb_rule_match"
 LABEL="not_Qualcomm"
 


### PR DESCRIPTION
This Android-based micro-four-thirds camera device, sold only in mainland
China, is identifying itself in lsusb as:

    05c6:9091 Qualcomm, Inc. Intex Aqua Fish & Jolla C Diagnostic Mode

Therefore, it's placed under the Qualcomm section.