### PR TITLE
Add OPPO Watch fastboot mode

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -481,6 +481,8 @@ ATTR{idProduct}=="2769", ENV{adb_adb}="yes"
 ATTR{idProduct}=="2764", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
 #   A94 5G
 ATTR{idProduct}=="2769", ENV{adb_adb}="yes"
+#   Oppo Watch, fastboot
+ATTR{idProduct}=="2024", ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Oppo"
 


### PR DESCRIPTION
Thank you for your work on these udev rules! They make all our lives easier :smile: 

ADB mode is handled by the recently added line for the Realme 8.