### PR TITLE
Add ZTE Nubia series

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -756,6 +756,28 @@ ATTR{idProduct}=="1351", ENV{adb_adb}="yes"
 ATTR{idProduct}=="1354", ENV{adb_adb}="yes"
 #   P685M LTE modem
 ATTR{idProduct}=="1275", ENV{adb_user}="yes"
+#   Nubia / RedMagic Series (NX***)
+#   See https://github.com/TadiT7/nubia_nx619j_dump/blob/NX619J-user-9-PKQ1.180929.001-eng.nubia.20181220.181559-release-keys/vendor/etc/init/hw/init.nubia.usb.rc
+#   ptp,adb
+ATTR{idProduct}=="ffd1", ENV{adb_adb}="yes"
+#   mtp,adb
+ATTR{idProduct}=="ffcf", ENV{adb_adb}="yes"
+#   mass_storage,adb
+ATTR{idProduct}=="ffcd", ENV{adb_adb}="yes"
+#   rndis,adb
+ATTR{idProduct}=="ffcb", ENV{adb_adb}="yes"
+#   modem,service,nema,adb
+ATTR{idProduct}=="ffc9", ENV{adb_adb}="yes"
+#   modem,service,nema,mass_storage,adb
+ATTR{idProduct}=="ffc7", ENV{adb_adb}="yes"
+#   diag,modem,mass_storage,adb
+ATTR{idProduct}=="ffb0", ENV{adb_adb}="yes"
+#   diag,modem,service,mass_storage,adb
+ATTR{idProduct}=="ffb2", ENV{adb_adb}="yes"
+#   adb
+ATTR{idProduct}=="ffc1", ENV{adb_adb}="yes"
+#   diag,mass_storage,adb
+ATTR{idProduct}=="ffc0", ENV{adb_adb}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_ZTE"
 


### PR DESCRIPTION
This patch was tested with Nubia Z11 miniS (NX549J), but should also work with more than fifty `NX***`-ish phones branded under ZTE, Nubia or RedMagic ([full list](https://www.nubia.com/active/nonguaranteedprice.html)).