### PR TITLE
Change fast to adbfast for Pixel C

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -160,7 +160,7 @@ ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
 ATTR{idProduct}=="4ee9", ENV{adb_adb}="yes"
 
 #   Pixel C Tablet
-ATTR{idProduct}=="5201", ENV{adb_fast}="yes"
+ATTR{idProduct}=="5201", ENV{adb_adbfast}="yes"
 ATTR{idProduct}=="5203", ENV{adb_adb}="yes"
 ATTR{idProduct}=="5208", ENV{adb_adb}="yes"
 


### PR DESCRIPTION
With the previous entry the rules did not allow for fastboot identification. Tested on the Pixel C.