### PR TITLE
Fix get current user instead of root on the automatic install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ adb devices
 # You should now see your device
 ```
 
+### Using the automtic install script
+1. Clone this repository
+2. Run the `install.sh` as root on your terminal
+
 ## To Contribute
 
 1. Fork this repository.

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ else
   groupadd adbusers
 fi
 
-usermod -a -G adbusers "$USER"
+usermod -a -G adbusers "$(logname)"
 udevadm control --reload-rules
 
 if [ "$USE_SERVICE_CMD" = "true" ]; then


### PR DESCRIPTION
Fixes the automated install script. The previous implementation always gets the root user added to the adbusers group instead of the username of the regular account (the one we usually use normally).