### PR TITLE
Add support for OnePlus Nord N10 4G in USB tethering mode

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -471,6 +471,8 @@ ATTR{idVendor}!="2a70", GOTO="not_OnePlus"
 ATTR{idProduct}=="4ee2", ENV{adb_adb}="yes"
 ATTR{idProduct}=="4ee6", ENV{adb_adb}="yes"
 ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
+#   OnePlus Nord N10 4G USB tethering mode
+ATTR{idProduct}=="9024", ENV{adb_adb}="yes"
 #   OnePlus 3T with Oreo MIDI mode 90bb=adb+midi, 9011=MTP, 904e=PTP
 ATTR{idProduct}=="90bb", ENV{adb_adb}="yes"
 ATTR{idProduct}=="9011", SYMLINK+="android_adb"


### PR DESCRIPTION
Hello there!

I've recently changed PCs, and this new one doesn't have a WiFi card + I'm waiting for an Ethernet cable. 
In the meantime I use my phone as WiFi receiver, and I noticed it works in all USB modes except USB tethering.
This line adds support for it.
`adb devices` shows the phone as `device` and I've been able to run `adb shell` or have Expo communicate with my device smoothly.
Note that I can't say for sure it'll work with the 5G edition of Nord N10s, as I don't have the device to test it, hence why I specified it's the older model.

Have a good day~