### PR TITLE
Meizu M6T and miscellaneous improvements

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -399,6 +399,8 @@ ATTR{idVendor}!="2a45", GOTO="not_Meizu"
 ATTR{idProduct}=="0c01", ENV{adb_adb}="yes"
 #   MX6
 ATTR{idProduct}=="0c02", ENV{adb_adb}="yes"
+#   M6T (untested; See <https://github.com/M0Rf30/android-udev-rules/issues/262>
+ATTR{idProduct}=="201c", ENV{adb_adb}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Meizu"
 

--- a/51-android.rules
+++ b/51-android.rules
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2022 JoesCat, M0Rf30 and contributors
-#
+# SPDX-FileCopyrightText: 2012-2023 JoesCat, M0Rf30 and contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # These rules refer to:

--- a/51-android.rules
+++ b/51-android.rules
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: 2012-2023 JoesCat, M0Rf30 and contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Latest version can be found at:
+# <https://github.com/M0Rf30/android-udev-rules>
+
 # These rules refer to:
-# https://developer.android.com/studio/run/device.html
+# <https://developer.android.com/studio/run/device.html>
 # and include many suggestions from Arch Linux, GitHub and other Communities.
-# Latest version can be found at: 
-# https://github.com/M0Rf30/android-udev-rules
+
 
 # Skip testing for android devices if device is not add, or usb
 ACTION!="add", ACTION!="bind", GOTO="android_usb_rules_end"
@@ -18,6 +20,7 @@ ENV{ID_USB_INTERFACES}=="*:0701??:*", ENV{adb_adb}="yes", GOTO="android_usb_rule
 
 LABEL="android_usb_rules_begin"
 # Devices listed here in android_usb_rules_{begin...end} are connected by USB
+
 # Acer
 ATTR{idVendor}!="0502", GOTO="not_Acer"
 #   Iconia Tab A1-830
@@ -59,7 +62,6 @@ ATTR{idProduct}=="03c8", ENV{adb_adbfast}="yes"
 ATTR{idProduct}=="03cb", ENV{adb_adbfast}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Amazon"
-
 
 # Archos
 ATTR{idVendor}!="0e79", GOTO="not_Archos"

--- a/51-android.rules
+++ b/51-android.rules
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2022 JoesCat, M0Rf30 and contributors
 #
-# SPDX-License-Identifier: GPL-3.0
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # These rules refer to:
 # https://developer.android.com/studio/run/device.html

--- a/README.md
+++ b/README.md
@@ -23,39 +23,40 @@ systemd
 # Clone this repository
 git clone https://github.com/M0Rf30/android-udev-rules.git
 cd android-udev-rules
-    
+
 # Copy rules file
 sudo cp -v 51-android.rules /etc/udev/rules.d/51-android.rules
-    
+
 # OR create a sym-link to the rules file - choose this option if you'd like to
 # update your udev rules using git.
 sudo ln -sf "$PWD"/51-android.rules /etc/udev/rules.d/51-android.rules
-    
+
 # Change file permissions
 sudo chmod a+r /etc/udev/rules.d/51-android.rules
-    
+
 # Add the adbusers group if it's doesn't already exist
 sudo cp android-udev.conf /usr/lib/sysusers.d/
 sudo systemd-sysusers
 
 # Add your user to the adbusers group
 sudo gpasswd -a $(whoami) adbusers
-    
+
 # Restart UDEV
 sudo udevadm control --reload-rules
 sudo systemctl restart systemd-udevd.service
-   
+
 # Restart the ADB server (back to Debian again)
 adb kill-server
-    
+
 # Replug your Android device and verify that USB debugging is enabled in
 # developer options
 adb devices
-    
+
 # You should now see your device
 ```
 
 ### Using the automtic install script
+
 1. Clone this repository
 2. Run the `install.sh` as root on your terminal
 

--- a/README.md
+++ b/README.md
@@ -66,3 +66,6 @@ adb devices
 2. Make your edits.
 3. TEST THEM!
 4. Create a pull request.
+
+You may also want to take a look at the
+[wiki](https://github.com/M0Rf30/android-udev-rules/wiki).

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,4 +3,3 @@ android-udev-rules (20220102-1) stable; urgency=low
   * Latest stable tag.
 
  -- Builder <builder@builder.com>  Sun, 02 Jan 2022 19:41:00 +0100
-

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: android-udev-rules
-Section: developer-tools
+Section: devel
 Priority: extra
 Maintainer: Simon Sickle <simon@simonsickle.com>
 Build-Depends: debhelper (>= 9)

--- a/debian/copyright
+++ b/debian/copyright
@@ -20,4 +20,3 @@ License: GPL-3+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
-

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 %:
-	dh $@ 
+	dh $@
 
 override_dh_auto_make:
 	make

--- a/rpm/android-udev-rules.spec
+++ b/rpm/android-udev-rules.spec
@@ -2,7 +2,7 @@ Name:           android-udev-rules
 Version:        20230310
 Release:        1%{?dist}
 Summary:        Udev rules to connect Android devices to your linux box
-License:        GPLv3+
+License:        GPL-3.0-or-later
 URL:            https://github.com/M0Rf30/android-udev-rules
 Source0:        https://raw.githubusercontent.com/M0Rf30/android-udev-rules/main/51-android.rules
 Source1:        https://raw.githubusercontent.com/M0Rf30/android-udev-rules/main/README.md

--- a/rpm/android-udev-rules.spec
+++ b/rpm/android-udev-rules.spec
@@ -55,4 +55,3 @@ systemctl restart systemd-udevd.service
 
 * Sun Jan 02 2022 Håkon Løvdal <kode@denkule.no> - 20220102-1
 - Latest stable tag.
-


### PR DESCRIPTION
See individual commits for details.

I'm not entirely sure which one of `adb_adb` and `adb_user` would suit better this untested device. I also assumed the license is GPL v3 (or later), as that's what was specified in the RMP|.deb metadata.

If that isn't right (or if any other part should be corrected) I can spin up a v2. Someone else amending the commits is also fine with me.