### PR TITLE
GOTO next LABEL after device found (for a faster rules script).

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -24,106 +24,106 @@ LABEL="android_usb_rules_begin"
 # Acer
 ATTR{idVendor}!="0502", GOTO="not_Acer"
 #   Iconia Tab A1-830
-ATTR{idProduct}=="3604", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="3604", GOTO="adbfast"
 #   Iconia Tab A210 (33cc=normal,33cb=debug)
-ATTR{idProduct}=="33cb", ENV{adb_adb}="yes"
+ATTR{idProduct}=="33cb", GOTO="adb"
 #   Iconia Tab A500
-ATTR{idProduct}=="3325", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="3325", GOTO="adbfast"
 #   Liquid (3202=normal,3203=debug)
-ATTR{idProduct}=="3203", ENV{adb_user}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="3203", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Acer"
 
 # Actions Semiconductor Co., Ltd
 #   Denver TAD 70111
-ATTR{idVendor}=="10d6", ATTR{idProduct}=="0c02", ENV{adb_adb}="yes"
+ATTR{idVendor}=="10d6", ATTR{idProduct}=="0c02", GOTO="adb"
 
 # ADVANCE (Need product specific rules)
 #   S5
-ATTR{idVendor}=="0a5c", ATTR{idProduct}=="e681", ENV{adb_adb}="yes"
+ATTR{idVendor}=="0a5c", ATTR{idProduct}=="e681", GOTO="adb"
 
 # Amazon Lab126
 ATTR{idVendor}!="1949", GOTO="not_Amazon"
 #   Amazon Kindle Fire
-ATTR{idProduct}=="0006", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0006", GOTO="adbfast"
 #   Amazon Kindle 8 2016 (giza) (0bb4:0c01=fastboot 0231=mtp 0232=adb,mtp 0233=ptp 0234=adb,ptp)
-ATTR{idProduct}=="0232", ENV{adb_adbmtp}="yes"
-ATTR{idProduct}=="0234", ENV{adb_adbptp}="yes"
+ATTR{idProduct}=="0232", GOTO="adbmtp"
+ATTR{idProduct}=="0234", GOTO="adbptp"
 #   Amazon Kindle 10 2021 (trona) (05e0=fastboot 05e1=mtp 05e1=chg 05e2=adb,mtp 05e3=ptp 05e4=adb,ptp 05e8=adb,chg=05e8 2046=midi 2048=adb,midi)
-ATTR{idProduct}=="05e0", ENV{adb_adbfast}="yes"
-ATTR{idProduct}=="05e2", ENV{adb_adbmtp}="yes"
-ATTR{idProduct}=="05e4", ENV{adb_adbptp}="yes"
-ATTR{idProduct}=="05e8", ENV{adb_adb}="yes"
-ATTR{idProduct}=="2048", ENV{adb_adbmidi}="yes"
+ATTR{idProduct}=="05e0", GOTO="adbfast"
+ATTR{idProduct}=="05e2", GOTO="adbmtp"
+ATTR{idProduct}=="05e4", GOTO="adbptp"
+ATTR{idProduct}=="05e8", GOTO="adb"
+ATTR{idProduct}=="2048", GOTO="adbmidi"
 #   Amazon Fire TV Stick Lite (3rd gen)
-ATTR{idProduct}=="03a8", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="03a8", GOTO="adbfast"
 #   Amazone Fire 7 (mustang)
-ATTR{idProduct}=="03c8", ENV{adb_adbfast}="yes"
-ATTR{idProduct}=="03cb", ENV{adb_adbfast}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="03c8", GOTO="adbfast"
+ATTR{idProduct}=="03cb", GOTO="adbfast"
+GOTO="android_usb_rules_end"
 LABEL="not_Amazon"
 
 # Archos
 ATTR{idVendor}!="0e79", GOTO="not_Archos"
 #   43
-ATTR{idProduct}=="1417", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="1417", GOTO="adbfast"
 #   101
-ATTR{idProduct}=="1411", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="1411", GOTO="adbfast"
 #   101 xs
-ATTR{idProduct}=="1549", ENV{adb_adbfast}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="1549", GOTO="adbfast"
+GOTO="android_usb_rules_end"
 LABEL="not_Archos"
 
 # Ascom
 ATTR{idVendor}!="1768", GOTO="not_Ascom"
-ATTR{idProduct}=="0007", ENV{adb_adb}="yes"
-ATTR{idProduct}=="000e", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
-ATTR{idProduct}=="0013", ENV{adb_adb}="yes"
-ATTR{idProduct}=="0011", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="0007", GOTO="adb"
+ATTR{idProduct}=="000e", GOTO="adb"
+ATTR{idProduct}=="4ee7", GOTO="adb"
+ATTR{idProduct}=="0013", GOTO="adb"
+ATTR{idProduct}=="0011", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Ascom"
 
 # ASUSTeK
 ATTR{idVendor}!="0b05", GOTO="not_Asus"
 #   False positive - accessory
 ATTR{idProduct}=="1???", GOTO="android_usb_rules_end"
-ENV{adb_user}="yes"
 #   Zenphone 2 (ZE500CL) (7770=adb 7773=mtp,adb 7777=ptp,adb   7775=rndis,adb,mass_storage 5F03=mtp,adb,pclink,mass_storage 5F07=ptp,adb,pclink 5F05=rndis,adb,pclink,mass_storage
-ATTR{idProduct}=="7770", SYMLINK+="android_adb"
-ATTR{idProduct}=="7773", SYMLINK+="android_adb"
-ATTR{idProduct}=="7777", SYMLINK+="android_adb"
-ATTR{idProduct}=="7775", SYMLINK+="android_adb"
-ATTR{idProduct}=="5F03", SYMLINK+="android_adb"
-ATTR{idProduct}=="5F07", SYMLINK+="android_adb"
-ATTR{idProduct}=="5F05", SYMLINK+="android_adb"
+ATTR{idProduct}=="7770", GOTO="adb"
+ATTR{idProduct}=="7773", GOTO="adb"
+ATTR{idProduct}=="7777", GOTO="adb"
+ATTR{idProduct}=="7775", GOTO="adb"
+ATTR{idProduct}=="5F03", GOTO="adb"
+ATTR{idProduct}=="5F07", GOTO="adb"
+ATTR{idProduct}=="5F05", GOTO="adb"
 #   Zenphone 4 (581f=mtp,adb 583f=rndis,adb)
-ATTR{idProduct}=="581f", SYMLINK+="android_adb"
-ATTR{idProduct}=="583f", SYMLINK+="android_adb"
+ATTR{idProduct}=="581f", GOTO="adb"
+ATTR{idProduct}=="583f", GOTO="adb"
 #   Zenphone 5 (4c90=normal,4c91=debug,4daf=Fastboot)
-ATTR{idProduct}=="4c91", SYMLINK+="android_adb"
-ATTR{idProduct}=="4daf", SYMLINK+="android_fastboot"
+ATTR{idProduct}=="4c91", GOTO="adb"
+ATTR{idProduct}=="4daf", GOTO="adbfast"
 #   Tegra APX
-ATTR{idProduct}=="7030", SYMLINK+="android_adb"
+ATTR{idProduct}=="7030", GOTO="adb"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Asus"
 
 # Azpen Onda
-ATTR{idVendor}=="1f3a", ENV{adb_user}="yes"
+ATTR{idVendor}=="1f3a", GOTO="user"
 
 # BQ
 ATTR{idVendor}!="2a47", GOTO="not_BQ"
 #   Aquaris 4.5
-ATTR{idProduct}=="0c02", ENV{adb_adbfast}="yes"
-ATTR{idProduct}=="2008", ENV{adb_adbfast}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="0c02", GOTO="adbfast"
+ATTR{idProduct}=="2008", GOTO="adbfast"
+GOTO="android_usb_rules_end"
 LABEL="not_BQ"
 
 # Castles
 ATTR{idVendor}!="0ca6", GOTO="not_Castles"
 #   Saturn1000-E
-ATTR{idProduct}=="a051", ENV{adb_user}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="a051", GOTO="user"
+GOTO="android_usb_rules_end"
 LABEL="not_Castles"
 
 # Dell (Need product specific rules)
@@ -132,44 +132,44 @@ LABEL="not_Castles"
 # Essential
 ATTR{idVendor}!="2e17", GOTO="not_Essential"
 #   Essential PH-1
-ATTR{idProduct}=="c009", ENV{adb_adb}="yes"
-ATTR{idProduct}=="c03[02]", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="c009", GOTO="adb"
+ATTR{idProduct}=="c03[02]", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Essential"
 
 # Fairphone 1 (see Hisense 109b)
 # Fairphone 2 (f005=tether, f00e=rndis, 90de=charge, 90dc=charge,adb f000=MTP, 9039=MTP,adb, 904d=PTP, 904e=PTP,adb, 9015=storage,adb, 9024=rndis,adb) 90bb=qualcom midi+adb
 ATTR{idVendor}!="2ae5", GOTO="not_Fairphone2"
-ATTR{idProduct}=="9015", ENV{adb_adb}="yes"
-ATTR{idProduct}=="9039", ENV{adb_adb}="yes"
-ATTR{idProduct}=="904e", ENV{adb_adb}="yes"
-ATTR{idProduct}=="90dc", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="9015", GOTO="adb"
+ATTR{idProduct}=="9039", GOTO="adb"
+ATTR{idProduct}=="904e", GOTO="adb"
+ATTR{idProduct}=="90dc", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Fairphone2"
 
 # Foxconn
 #   Commtiva Z71, Geeksphone One
-ATTR{idVendor}=="0489", ATTR{idProduct}=="c001", ENV{adb_adb}="yes"
+ATTR{idVendor}=="0489", ATTR{idProduct}=="c001", GOTO="adb"
 
 # Fujitsu/Fujitsu Toshiba
-ATTR{idVendor}=="04c5", ENV{adb_user}="yes"
+ATTR{idVendor}=="04c5", GOTO="user"
 
 # Fuzhou Rockchip Electronics
 #   Mediacom Smartpad 715i
 ATTR{idVendor}!="2207", GOTO="not_Fuzhou"
-ATTR{idProduct}=="0000", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0000", GOTO="adb"
 #   Ubislate 7Ci
-ATTR{idProduct}=="0010", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0010", GOTO="adb"
 #   Anbernic RG353P - AOSP12beta#1 (0003=rndis 0006=adb,chg 0007=mtp 0008=ptp 0013=adb,rndis 0017=adb,mtp 0018=adb,ptp)
-ATTR{idProduct}=="0006", ENV{adb_adb}="yes"
-ATTR{idProduct}=="0013", ENV{adb_adbtet}="yes"
-ATTR{idProduct}=="0017", ENV{adb_adbmtp}="yes"
-ATTR{idProduct}=="0018", ENV{adb_adbptp}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="0006", GOTO="adb"
+ATTR{idProduct}=="0013", GOTO="adbrndis"
+ATTR{idProduct}=="0017", GOTO="adbmtp"
+ATTR{idProduct}=="0018", GOTO="adbptp"
+GOTO="android_usb_rules_end"
 LABEL="not_Fuzhou"
 
 # Garmin-Asus
-ATTR{idVendor}=="091e", ENV{adb_user}="yes"
+ATTR{idVendor}=="091e", GOTO="user"
 
 # Google
 ATTR{idVendor}!="18d1", GOTO="not_Google"
@@ -179,75 +179,74 @@ ATTR{idVendor}!="18d1", GOTO="not_Google"
 #   Pico i.MX7 Dual Development Board 4ee7=debug
 #   PinePhone (v1.2) (4ee0=fast 4ee1=mtp, 4ee2=mtp,adb 4ee3=rndis 4ee4=rndis,adb 4ee5=ptp, 4ee6=ptp,adb 4ee7=adb)
 #   Yandex Phone 4ee7=debug
-ATTR{idProduct}=="4ee0", ENV{adb_adbfast}="yes"
-ATTR{idProduct}=="4ee2", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4ee4", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4ee6", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4ee9", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee0", GOTO="adbfast"
+ATTR{idProduct}=="4ee2", GOTO="adb"
+ATTR{idProduct}=="4ee4", GOTO="adb"
+ATTR{idProduct}=="4ee6", GOTO="adb"
+ATTR{idProduct}=="4ee7", GOTO="adb"
+ATTR{idProduct}=="4ee9", GOTO="adb"
 
 #   Tensor Pixel phones (Pixel 7/7 pro/6/6A/6 Pro) 4eeb=cdc-ncm; 4eec=cdc-ncm,adb
-ATTR{idProduct}=="4eec", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4eec", GOTO="adb"
 
 #   Pixel C Tablet
-ATTR{idProduct}=="5201", ENV{adb_adbfast}="yes"
-ATTR{idProduct}=="5203", ENV{adb_adb}="yes"
-ATTR{idProduct}=="5208", ENV{adb_adb}="yes"
+ATTR{idProduct}=="5201", GOTO="adbfast"
+ATTR{idProduct}=="5203", GOTO="adb"
+ATTR{idProduct}=="5208", GOTO="adb"
 
-ATTR{idProduct}=="2d00", ENV{adb_adb}="yes"
-ATTR{idProduct}=="2d01", ENV{adb_adb}="yes"
-ATTR{idProduct}=="2d03", ENV{adb_adb}="yes"
-ATTR{idProduct}=="2d05", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2d00", GOTO="adb"
+ATTR{idProduct}=="2d01", GOTO="adb"
+ATTR{idProduct}=="2d03", GOTO="adb"
+ATTR{idProduct}=="2d05", GOTO="adb"
 #   Nexus 7
-ATTR{idProduct}=="4e42", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4e40", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="4e42", GOTO="adb"
+ATTR{idProduct}=="4e40", GOTO="adbfast"
 #   Nexus 5, Nexus 10
-ATTR{idProduct}=="4ee1", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="4ee1", GOTO="adbfast"
 #   Nexus S (4e22=mass_storage,adb 4e24=rndis,adb)
 #   See https://android.googlesource.com/device/samsung/crespo/+/android-4.1.2_r2.1/init.herring.usb.rc
-ATTR{idProduct}=="4e22", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4e24", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4e20", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="4e22", GOTO="adb"
+ATTR{idProduct}=="4e24", GOTO="adb"
+ATTR{idProduct}=="4e20", GOTO="adbfast"
 #   Galaxy Nexus, Galaxy Nexus (GSM)
-ATTR{idProduct}=="4e30", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="4e30", GOTO="adbfast"
 #   Nexus One (4e11=normal,4e12=debug,0fff=debug)
-ATTR{idProduct}=="4e12", ENV{adb_adb}="yes"
-ATTR{idProduct}=="0fff", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="4e12", GOTO="adb"
+ATTR{idProduct}=="0fff", GOTO="adbfast"
 #   Generic and unspecified debug interface (test after d00?)
 #   examples: Xiaomi Mi/Redmi 2, Anbernic RG353P
-ATTR{idProduct}=="d00d", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="d00d", GOTO="adbfast"
 #   Recovery adb entry for Nexus Family (orig d001, OP3 has 18d1:d002)
-ATTR{idProduct}=="d00?", ENV{adb_adb}="yes"
+ATTR{idProduct}=="d00?", GOTO="adb"
 
 # Other vendors that also used duplicated Google's idVendor code follows:
 # IDEA XDS-1078 (debug=2c11)
-ATTR{idProduct}=="2c11", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="2c11", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Google"
 
 # Haier
-ATTR{idVendor}=="201e", ENV{adb_user}="yes"
+ATTR{idVendor}=="201e", GOTO="user"
 
 # Hisense (includes Fairphone 1)
-ATTR{idVendor}=="109b", ENV{adb_user}="yes"
+ATTR{idVendor}=="109b", GOTO="user"
 
 # Honeywell/Foxconn
 ATTR{idVendor}!="0c2e", GOTO="not_Honeywell"
 #   D70e
-ATTR{idProduct}=="0ba3", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="0ba3", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Honeywell"
 
 # HTC
 ATTR{idVendor}!="0bb4", GOTO="not_HTC"
-ENV{adb_user}="yes"
 #   fastboot mode enabled
-ATTR{idProduct}=="0fff", ENV{adb_adbfast}="yes", GOTO="android_usb_rule_match"
+ATTR{idProduct}=="0fff", GOTO="adbfast"
 #   ADP1, Dream, G1, HD2, Magic, Tatoo (0c01=mass_storage)
 #   NOTE: Amazon Kindle 8 2016 (giza) (fastboot=0bb4:0c01 conflicts with mass storage=0c01)
-ATTR{idProduct}=="0c02", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0c02", GOTO="adbfast"
 #   ChaCha
-ATTR{idProduct}=="0cb2", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0cb2", GOTO="adbfast"
 #   Desire (Bravo)
 ATTR{idProduct}=="0c87", SYMLINK+="android_adb"
 #   Desire HD
@@ -255,11 +254,11 @@ ATTR{idProduct}=="0ca2", SYMLINK+="android_adb"
 #   Desire S (Saga)
 ATTR{idProduct}=="0cab", SYMLINK+="android_adb"
 #   Desire Z
-ATTR{idProduct}=="0c91", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0c91", GOTO="adbfast"
 #   Evo Shift
 ATTR{idProduct}=="0ca5", SYMLINK+="android_adb"
 #   Hero H2000
-ATTR{idProduct}=="0001", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0001", GOTO="adbfast"
 #   Hero (GSM), Desire
 ATTR{idProduct}=="0c99", SYMLINK+="android_adb"
 #   Hero (CDMA)
@@ -284,23 +283,23 @@ ATTR{idProduct}=="0e03", SYMLINK+="android_adb"
 #   Vision
 ATTR{idProduct}=="0c91", SYMLINK+="android_adb"
 #   Wildfire
-ATTR{idProduct}=="0c8b", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0c8b", GOTO="adbfast"
 #   Wildfire S
-ATTR{idProduct}=="0c86", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0c86", GOTO="adbfast"
 #   Zopo ZP900, Fairphone
-ATTR{idProduct}=="0c03", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0c03", GOTO="adbfast"
 #   Zopo C2
 ATTR{idProduct}=="2008", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_HTC"
 
 # Huawei
 ATTR{idVendor}!="12d1", GOTO="not_Huawei"
-ENV{adb_user}="yes"
 #   IDEOS
-ATTR{idProduct}=="1038", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="1038", GOTO="adbfast"
 #   U8850 Vision
-ATTR{idProduct}=="1021", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="1021", GOTO="adbfast"
 #   HiKey adb
 ATTR{idProduct}=="1057", SYMLINK+="android_adb"
 #   HiKey usbnet
@@ -318,49 +317,50 @@ ATTR{idProduct}=="107e", SYMLINK+="android_adb"
 ATTR{idProduct}=="1c2c", SYMLINK+="android_adb"
 #   Mate 9
 ATTR{idProduct}=="107e", SYMLINK+="android_adb"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Huawei"
 
 # Intel
 ATTR{idVendor}!="8087", GOTO="not_Intel"
 #   Geeksphone Revolution
-ATTR{idProduct}=="0a16", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0a16", GOTO="adb"
 #   Chuwi Hi 10 Pro (HQ64)
-ATTR{idProduct}=="2a65", ENV{adb_adb}="yes"
-ATTR{idProduct}=="07ef", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2a65", GOTO="adb"
+ATTR{idProduct}=="07ef", GOTO="adb"
 #   Asus ZenFone 2 (ADB Sideload in TWRP Recovery)
-ATTR{idProduct}=="0a5d", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0a5d", GOTO="adb"
 #   Reference Boards using kernelflinger
 #   See https://github.com/intel/kernelflinger/blob/master/libefiusb/usb.c#L56
-ATTR{idProduct}=="09ef", ENV{adb_adbfast}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="09ef", GOTO="adbfast"
+GOTO="android_usb_rules_end"
 LABEL="not_Intel"
 
 # IUNI
 ATTR{idVendor}!="271d", GOTO="not_IUNI"
 #   U3
-ATTR{idProduct}=="bf39", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="bf39", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_IUNI"
 
 # K-Touch
-ATTR{idVendor}=="24e3", ENV{adb_user}="yes"
+ATTR{idVendor}=="24e3", GOTO="user"
 
 # KT Tech
-ATTR{idVendor}=="2116", ENV{adb_user}="yes"
+ATTR{idVendor}=="2116", GOTO="user"
 
 # Kyocera
 #ATTR{idVendor}=="0482", ENV{adb_user}="yes"
 
 # Lenovo
-ATTR{idVendor}=="17ef", ENV{adb_user}="yes"
+ATTR{idVendor}=="17ef", GOTO="user"
 
 # LeTv (LeECo)
 ATTR{idVendor}!="2b0e", GOTO="not_letv"
-ENV{adb_user}="yes"
 #   LEX720 LeEco Pro3 6GB (610c=normal,610d=debug, 610b=camera)
-ATTR{idProduct}=="610d", ENV{adb_adbfast}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="610d", GOTO="adbfast"
+ENV{adb_user}="yes"
+GOTO="android_usb_rules_end"
 LABEL="not_letv"
 
 # LG
@@ -397,35 +397,34 @@ LABEL="not_LG"
 # Meizu
 ATTR{idVendor}!="2a45", GOTO="not_Meizu"
 #   M1E
-ATTR{idProduct}=="0c01", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0c01", GOTO="adb"
 #   MX6
-ATTR{idProduct}=="0c02", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0c02", GOTO="adb"
 #   M6T (untested; See <https://github.com/M0Rf30/android-udev-rules/issues/262>
-ATTR{idProduct}=="201c", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="201c", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Meizu"
 
 # Micromax
 ATTR{idVendor}!="2a96", GOTO="not_Micromax"
 #   P702
-ATTR{idProduct}=="201d", ENV{adb_adbfast}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="201d", GOTO="adbfast"
+GOTO="android_usb_rules_end"
 LABEL="not_Micromax"
 
 # Microsoft
 ATTR{idVendor}!="045e", GOTO="not_Microsoft"
+#   Surface Duo
+ATTR{idProduct}=="0c26", GOTO="adbfast"
 #   False positive xbox controllers 028e, 02ea, 0719
 ATTR{idProduct}=="02??", GOTO="android_usb_rules_end"
 ATTR{idProduct}=="07??", GOTO="android_usb_rules_end"
 ENV{adb_user}="yes"
-#   Surface Duo
-ATTR{idProduct}=="0c26", ENV{adb_adbfast}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Microsoft"
 
 # Motorola
 ATTR{idVendor}!="22b8", GOTO="not_Motorola"
-ENV{adb_user}="yes"
 #   CLIQ XT/Quench
 ATTR{idProduct}=="2d66", SYMLINK+="android_adb"
 #   Defy/MB525
@@ -433,77 +432,78 @@ ATTR{idProduct}=="428c", SYMLINK+="android_adb"
 #   Droid
 ATTR{idProduct}=="41db", SYMLINK+="android_adb"
 #   Xoom ID 1
-ATTR{idProduct}=="70a8", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="70a8", GOTO="adbfast"
 #   Xoom ID 2
-ATTR{idProduct}=="70a9", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="70a9", GOTO="adbfast"
 #   Razr XT912
-ATTR{idProduct}=="4362", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="4362", GOTO="adbfast"
 #   Moto XT1052
-ATTR{idProduct}=="2e83", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="2e83", GOTO="adbfast"
 #   Moto E/G
-ATTR{idProduct}=="2e76", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="2e76", GOTO="adbfast"
 #   Moto E/G (Dual SIM)
-ATTR{idProduct}=="2e80", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="2e80", GOTO="adbfast"
 #   Moto E/G (Global GSM)
-ATTR{idProduct}=="2e82", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="2e82", GOTO="adbfast"
 #   Moto x4
-ATTR{idProduct}=="2e81", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="2e81", GOTO="adbfast"
 #   Droid Turbo 2
-ATTR{idProduct}=="2ea4", ENV{adb_adbfast}="yes", SYMLINK+="android%n"
+ATTR{idProduct}=="2ea4", GOTO="adbfast"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Motorola"
 
 # MTK (MediaTek Inc)
 ATTR{idVendor}!="0e8d", GOTO="not_MTK"
-ENV{adb_user}="yes"
 #   Umidigi F1
-ATTR{idProduct}=="201c", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="201c", GOTO="adbfast"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_MTK"
 
 # NEC
-ATTR{idVendor}=="0409", ENV{adb_user}="yes"
+ATTR{idVendor}=="0409", GOTO="user"
 
 # Nextbit
-ATTR{idVendor}=="2c3f", ENV{adb_user}="yes"
+ATTR{idVendor}=="2c3f", GOTO="user"
 
 # Nokia X
-ATTR{idVendor}=="0421", ENV{adb_user}="yes"
+ATTR{idVendor}=="0421", GOTO="user"
 
 # Nokia 3
-ATTR{idVendor}=="2e04", ENV{adb_user}="yes"
+ATTR{idVendor}=="2e04", GOTO="user"
 
 # Nook (Barnes & Noble)
-ATTR{idVendor}=="2080", ENV{adb_user}="yes"
+ATTR{idVendor}=="2080", GOTO="user"
 
 # Nvidia
 ATTR{idVendor}!="0955", GOTO="not_Nvidia"
-ENV{adb_user}="yes"
 #   Audi SDIS Rear Seat Entertainment Tablet
 #   Folio
 ATTR{idProduct}=="7000", SYMLINK+="android_fastboot"
-ATTR{idProduct}=="7100", ENV{adb_user}="yes"
+ATTR{idProduct}=="7100", GOTO="user"
 #   SHIELD Tablet (debug)
-ATTR{idProduct}=="cf05", ENV{adb_adb}="yes"
-ATTR{idProduct}=="cf09", ENV{adb_adb}="yes"
+ATTR{idProduct}=="cf05", GOTO="adb"
+ATTR{idProduct}=="cf09", GOTO="adb"
 #   Shield TV
 ATTR{idProduct}=="b442", SYMLINK+="android_fastboot"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Nvidia"
 
 # Oculus
-ATTR{idVendor}=="2833", ENV{adb_user}="yes"
+ATTR{idVendor}=="2833", GOTO="user"
 
 # OnePlus(Oreo)
 ATTR{idVendor}!="2a70", GOTO="not_OnePlus"
 #   OnePlus 6, 4ee1=charging, 4ee2=MTP+debug, 4ee6=PTP+debug, 4ee7=charging+debug
-ATTR{idProduct}=="4ee2", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4ee6", ENV{adb_adb}="yes"
-ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee2", GOTO="adb"
+ATTR{idProduct}=="4ee6", GOTO="adb"
+ATTR{idProduct}=="4ee7", GOTO="adb"
 #   OnePlus Nord N10 4G USB tethering mode
-ATTR{idProduct}=="9024", ENV{adb_adb}="yes"
+ATTR{idProduct}=="9024", GOTO="adb"
 #   OnePlus 3T with Oreo MIDI mode 90bb=adb+midi, 9011=MTP, 904e=PTP
-ATTR{idProduct}=="90bb", ENV{adb_adb}="yes"
+ATTR{idProduct}=="90bb", GOTO="adb"
 ATTR{idProduct}=="9011", SYMLINK+="android_adb"
 ATTR{idProduct}=="904e", SYMLINK+="android_adb"
 GOTO="android_usb_rule_match"
@@ -512,50 +512,50 @@ LABEL="not_OnePlus"
 # Oppo
 ATTR{idVendor}!="22d9", GOTO="not_Oppo"
 #   Find 5 (2767=debug)
-ATTR{idProduct}=="2767", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2767", GOTO="adb"
 #   Realme 8
-ATTR{idProduct}=="2769", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2769", GOTO="adb"
 ATTR{idProduct}=="2764", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
 #   A94 5G
-ATTR{idProduct}=="2769", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2769", GOTO="adb"
 #   Oppo Watch, fastboot
-ATTR{idProduct}=="2024", ENV{adb_user}="yes"
+ATTR{idProduct}=="2024", GOTO="user"
 #   RMX3231 - Realme C11 20221, normal, rndis, mtp
-ATTR{idProduct}=="200e", ENV{adb_user}="yes"
-ATTR{idProduct}=="2028", ENV{adb_user}="yes"
-ATTR{idProduct}=="2026", ENV{adb_user}="yes"
+ATTR{idProduct}=="200e", GOTO="user"
+ATTR{idProduct}=="2028", GOTO="user"
+ATTR{idProduct}=="2026", GOTO="user"
 #   OnePlus 8T (22d9:2771=adb,PTP, 22d9:2772=adb,MTP)
-ATTR{idProduct}=="2771", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2771", GOTO="adb"
 ATTR{idProduct}=="2772", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
 GOTO="android_usb_rule_match"
 LABEL="not_Oppo"
 
 # OTGV
-ATTR{idVendor}=="2257", ENV{adb_user}="yes"
+ATTR{idVendor}=="2257", GOTO="user"
 
 # Pantech (SK Teletech Co, Ltd.)
-ATTR{idVendor}=="10a9", ENV{adb_user}="yes"
+ATTR{idVendor}=="10a9", GOTO="user"
 
 # Parrot SA (Car HUD)
-ATTR{idVendor}=="19cf", ENV{adb_user}="yes"
+ATTR{idVendor}=="19cf", GOTO="user"
 
 # Pegatron
-ATTR{idVendor}=="1d4d", ENV{adb_user}="yes"
+ATTR{idVendor}=="1d4d", GOTO="user"
 
 # Philips (and NXP)
-ATTR{idVendor}=="0471", ENV{adb_user}="yes"
+ATTR{idVendor}=="0471", GOTO="user"
 
 # Pico
-ATTR{idVendor}=="2d40", ENV{adb_user}="yes"
+ATTR{idVendor}=="2d40", GOTO="user"
 
 # PMC-Sierra, (Panasonic Mobile communications, Matsushita)
-ATTR{idVendor}=="04da", ENV{adb_user}="yes"
+ATTR{idVendor}=="04da", GOTO="user"
 
 # Point Mobile
 ATTR{idVendor}!="2a48", GOTO="not_Point_Mobile"
 #   PM90
-ATTR{idProduct}=="5101", ENV{adb_user}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="5101", GOTO="user"
+GOTO="android_usb_rules_end"
 LABEL="not_Point_Mobile"
 
 # Polar
@@ -569,7 +569,6 @@ LABEL="not_Polar"
 
 # Qualcomm (Wearners also 05c6)
 ATTR{idVendor}!="05c6", GOTO="not_Qualcomm"
-ENV{adb_user}="yes"
 #   Geeksphone Zero
 ATTR{idProduct}=="9025", SYMLINK+="android_adb"
 #   OnePlus One
@@ -582,7 +581,7 @@ ATTR{idProduct}=="900e", SYMLINK+="android_adb"
 ATTR{idProduct}=="676c", SYMLINK+="android_adb"
 #   Snapdragon, OnePlus 3T w/ Oreo MIDI mode (90bb=adb,midi, 9011=MTP, 904e=PTP)
 #   Xiaomi A1 (90bb=midi+adb)
-ATTR{idProduct}=="90bb", ENV{adb_adb}="yes"
+ATTR{idProduct}=="90bb", GOTO="adb"
 #   OnePlus 5 / 6 / 6T
 ATTR{idProduct}=="9011", SYMLINK+="android_adb"
 #   OnePlus 6 / Asia
@@ -590,67 +589,68 @@ ATTR{idProduct}=="f003", SYMLINK+="android_adb"
 #   Yongnuo YN450m (identified in lsusb as Intex Aqua Fish & Jolla C Diagnostic Mode)
 ATTR{idProduct}=="9091", SYMLINK+="android_adb"
 #   Wileyfox Swift 2 Plus
-ATTR{idProduct}=="0001", ENV{adb_user}="yes"
+ATTR{idProduct}=="0001", GOTO="user"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Qualcomm"
 
 # Razer USA, Ltd.
 ATTR{idVendor}!="1532", GOTO="not_Razer"
 #   Razer Phone 2
-ATTR{idProduct}=="9050", ENV{adb_adbfast}="yes"
-ATTR{idProduct}=="9051", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="9050", GOTO="adbfast"
+ATTR{idProduct}=="9051", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Razer"
 
 # Research In Motion, Ltd.
 ATTR{idVendor}!="0fca", GOTO="not_RIM"
 #   BlackBerry DTEK60
-ATTR{idProduct}=="8042", ENV{adb_fastboot}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="8042", GOTO="adbfast"
+GOTO="android_usb_rules_end"
 LABEL="not_RIM"
 
 # Samsung
 ATTR{idVendor}!="04e8", GOTO="not_Samsung"
 #   False positive printer
 ATTR{idProduct}=="3???", GOTO="android_usb_rules_end"
-ENV{adb_user}="yes"
 #   Galaxy i5700
-ATTR{idProduct}=="681c", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="681c", GOTO="adbfast"
 #   Galaxy i5800 (681c=debug,6601=fastboot,68a0=mediaplayer)
 ATTR{idProduct}=="681c", SYMLINK+="android_adb"
 ATTR{idProduct}=="6601", SYMLINK+="android_fastboot"
 ATTR{idProduct}=="68a9", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
 #   Galaxy i7500
-ATTR{idProduct}=="6640", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="6640", GOTO="adbfast"
 #   Galaxy i9000 S, i9300 S3
 ATTR{idProduct}=="6601", SYMLINK+="android_adb"
 ATTR{idProduct}=="685d", MODE="0660"
 ATTR{idProduct}=="68c3", MODE="0660"
 #   Galaxy Ace (S5830) "Cooper"
-ATTR{idProduct}=="689e", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="689e", GOTO="adbfast"
 #   Galaxy Tab
-ATTR{idProduct}=="6877", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="6877", GOTO="adbfast"
 #   Galaxy Nexus (GSM) (6860=mtp,adb 6864=rndis,adb 6866=ptp,adb)
 ATTR{idProduct}=="6860", SYMLINK+="android_adb"
 ATTR{idProduct}=="6864", SYMLINK+="android_adb"
 ATTR{idProduct}=="6866", SYMLINK+="android_adb"
 #   Galaxy Core, Tab 10.1, i9100 S2, i9300 S3, N5100 Note (8.0), Galaxy S3 SHW-M440S 3G (Korea only)
-ATTR{idProduct}=="685e", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="685e", GOTO="adbfast"
 #   Galaxy i9300 S3
 ATTR{idProduct}=="6866", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
 #   Galaxy S4 GT-I9500
 ATTR{idProduct}=="685d", SYMLINK+="android_adb"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Samsung"
 
 # Sharp
-ATTR{idVendor}=="04dd", ENV{adb_user}="yes"
+ATTR{idVendor}=="04dd", GOTO="user"
 
 # SK Telesys
-ATTR{idVendor}=="1f53", ENV{adb_user}="yes"
+ATTR{idVendor}=="1f53", GOTO="user"
 
 # Sonim
-ATTR{idVendor}=="1d9c", ENV{adb_user}="yes"
+ATTR{idVendor}=="1d9c", GOTO="user"
 
 # Sony
 ATTR{idVendor}!="054c", GOTO="not_Sony"
@@ -666,7 +666,6 @@ LABEL="not_Sony"
 
 # Sony Ericsson
 ATTR{idVendor}!="0fce", GOTO="not_Sony_Ericsson"
-ENV{adb_user}="yes"
 #   Xperia X10 mini (3137=mass_storage)
 ATTR{idProduct}=="2137", SYMLINK+="android_adb"
 #   Xperia X10 mini pro (3138=mass_storage)
@@ -676,86 +675,87 @@ ATTR{idProduct}=="2149", SYMLINK+="android_adb"
 #   Xperia X12 (e14f=mass_storage)
 ATTR{idProduct}=="614f", SYMLINK+="android_adb"
 #   Xperia Arc S
-ATTR{idProduct}=="414f", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="414f", GOTO="adbfast"
 #   Xperia Neo V (6156=debug,0dde=fastboot)
 ATTR{idProduct}=="6156", SYMLINK+="android_adb"
 ATTR{idProduct}=="0dde", SYMLINK+="android_fastboot"
 #   Xperia S
-ATTR{idProduct}=="5169", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="5169", GOTO="adbfast"
 #   Xperia SP
-ATTR{idProduct}=="6195", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="6195", GOTO="adbfast"
 #   Xperia L
-ATTR{idProduct}=="5192", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="5192", GOTO="adbfast"
 #   Xperia Mini Pro
-ATTR{idProduct}=="0166", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0166", GOTO="adbfast"
 #   Xperia V
-ATTR{idProduct}=="0186", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="0186", GOTO="adbfast"
 #   Xperia Acro S
-ATTR{idProduct}=="5176", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="5176", GOTO="adbfast"
 #   Xperia Z1 Compact
-ATTR{idProduct}=="51a7", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="51a7", GOTO="adbfast"
 #   Xperia Z2
-ATTR{idProduct}=="51ba", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="51ba", GOTO="adbfast"
 #   Xperia Z3
-ATTR{idProduct}=="01af", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="01af", GOTO="adbfast"
 #   Xperia Z3 Compact
-ATTR{idProduct}=="01bb", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="01bb", GOTO="adbfast"
 #   Xperia Z3+ Dual
-ATTR{idProduct}=="51c9", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="51c9", GOTO="adbfast"
 #   Xperia XZ
-ATTR{idProduct}=="51e7", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="51e7", GOTO="adbfast"
 #   Xperia XZ1 Compact
-ATTR{idProduct}=="01f4", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="01f4", GOTO="adbfast"
 #   Xperia XZ2 Compact
-ATTR{idProduct}=="b00b", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="b00b", GOTO="adbfast"
 #   Xperia 5 II
-ATTR{idProduct}=="020d", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="020d", GOTO="adbfast"
 #   Xperia Z Ultra
-ATTR{idProduct}=="519c", ENV{adb_adbfast}="yes"
+ATTR{idProduct}=="519c", GOTO="adbfast"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Sony_Ericsson"
 
 # Spectralink
-ATTR{idVendor}=="1973", ENV{adb_user}="yes"
+ATTR{idVendor}=="1973", GOTO="user"
 
 # Spreadtrum
-ATTR{idVendor}=="1782", ENV{adb_user}="yes"
+ATTR{idVendor}=="1782", GOTO="user"
 
 # T & A Mobile Phones
 ATTR{idVendor}!="1bbb", GOTO="not_T_A_Mobile"
-ENV{adb_user}="yes"
 #   Alcatel 1 2019 5033F
-ATTR{idProduct}=="0c01", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0c01", GOTO="adb"
 #   Alcatel OT991D
-ATTR{idProduct}=="00f2", ENV{adb_adb}="yes"
+ATTR{idProduct}=="00f2", GOTO="adb"
 #   Alcatel OT6012A
-ATTR{idProduct}=="0167", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0167", GOTO="adb"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_T_A_Mobile"
 
 # Teleepoch
-ATTR{idVendor}=="2340", ENV{adb_user}="yes"
+ATTR{idVendor}=="2340", GOTO="user"
 
 # Texas Instruments UsbBoot
-ATTR{idVendor}=="0451", ATTR{idProduct}=="d00f", ENV{adb_user}="yes"
-ATTR{idVendor}=="0451", ATTR{idProduct}=="d010", ENV{adb_user}="yes"
+ATTR{idVendor}=="0451", ATTR{idProduct}=="d00f", GOTO="user"
+ATTR{idVendor}=="0451", ATTR{idProduct}=="d010", GOTO="user"
 
 # Toshiba
-ATTR{idVendor}=="0930", ENV{adb_user}="yes"
+ATTR{idVendor}=="0930", GOTO="user"
 
 # Unitech Electronics
 ATTR{idVendor}!="2e8e", GOTO="not_Unitech_Electronics"
-ENV{adb_user}="yes"
 #   EA630 (96e1=normal,96e7=debug)
-ATTR{idProduct}=="96e7", ENV{adb_adb}="yes"
+ATTR{idProduct}=="96e7", GOTO="adb"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Unitech_Electronics"
 
 # Vivo
-ATTR{idVendor}=="2d95", ENV{adb_user}="yes"
+ATTR{idVendor}=="2d95", GOTO="user"
 
 # Wileyfox
-ATTR{idVendor}=="2970", ENV{adb_user}="yes"
+ATTR{idVendor}=="2970", GOTO="user"
 
 # XiaoMi
 ATTR{idVendor}!="2717", GOTO="not_XiaoMi"
@@ -797,91 +797,130 @@ LABEL="not_XiaoMi"
 
 # Yota
 ATTR{idVendor}!="2916", GOTO="not_Yota"
-ENV{adb_user}="yes"
 #   YotaPhone2 (f003=normal,9139=debug)
-ATTR{idProduct}=="9139", ENV{adb_adb}="yes"
+ATTR{idProduct}=="9139", GOTO="adb"
+ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Yota"
 
 # YU
-ATTR{idVendor}=="1ebf", ENV{adb_user}="yes"
+ATTR{idVendor}=="1ebf", GOTO="user"
 
 # Zebra
 ATTR{idVendor}!="05e0", GOTO="not_Zebra"
 #   TC55
-ATTR{idProduct}=="2101", ENV{adb_adb}="yes"
+ATTR{idProduct}=="2101", GOTO="adb"
 #   TC72
-ATTR{idProduct}=="2106", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="2106", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_Zebra"
 
 # ZTE
 ATTR{idVendor}!="19d2", GOTO="not_ZTE"
 #   ZTE Blade A5 2020
 #   mtp,adb
-ATTR{idProduct}=="0306", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0306", GOTO="adb"
 #   ptp,adb
-ATTR{idProduct}=="0310", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0310", GOTO="adb"
 #   cdrom,adb
-ATTR{idProduct}=="0501", ENV{adb_adb}="yes"
+ATTR{idProduct}=="0501", GOTO="adb"
 #   charging,adb
-ATTR{idProduct}=="1352", ENV{adb_adb}="yes"
+ATTR{idProduct}=="1352", GOTO="adb"
 #   rndis,adb
-ATTR{idProduct}=="1373", ENV{adb_adb}="yes"
+ATTR{idProduct}=="1373", GOTO="adb"
 #   Blade (1353=normal,1351=debug)
-ATTR{idProduct}=="1351", ENV{adb_adb}="yes"
+ATTR{idProduct}=="1351", GOTO="adb"
 #   Blade S (Crescent, Orange San Francisco 2) (1355=normal,1354=debug)
-ATTR{idProduct}=="1354", ENV{adb_adb}="yes"
+ATTR{idProduct}=="1354", GOTO="adb"
 #   P685M LTE modem
-ATTR{idProduct}=="1275", ENV{adb_user}="yes"
+ATTR{idProduct}=="1275", GOTO="user"
 #   MF286[A] internal LTE modem
-ATTR{idProduct}=="1432", ENV{adb_user}="yes"
+ATTR{idProduct}=="1432", GOTO="user"
 #   MF286D internal LTE modem
-ATTR{idProduct}=="1485", ENV{adb_user}="yes"
+ATTR{idProduct}=="1485", GOTO="user"
 #   MF286R internal LTE modem
-ATTR{idProduct}=="1489", ENV{adb_user}="yes"
+ATTR{idProduct}=="1489", GOTO="user"
 #   Nubia / RedMagic Series (NX***)
 #   See https://github.com/TadiT7/nubia_nx619j_dump/blob/NX619J-user-9-PKQ1.180929.001-eng.nubia.20181220.181559-release-keys/vendor/etc/init/hw/init.nubia.usb.rc
 #   ptp,adb
-ATTR{idProduct}=="ffd1", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffd1", GOTO="adb"
 #   mtp,adb
-ATTR{idProduct}=="ffcf", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffcf", GOTO="adb"
 #   mass_storage,adb
-ATTR{idProduct}=="ffcd", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffcd", GOTO="adb"
 #   rndis,adb
-ATTR{idProduct}=="ffcb", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffcb", GOTO="adb"
 #   modem,service,nema,adb
-ATTR{idProduct}=="ffc9", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffc9", GOTO="adb"
 #   modem,service,nema,mass_storage,adb
-ATTR{idProduct}=="ffc7", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffc7", GOTO="adb"
 #   diag,modem,mass_storage,adb
-ATTR{idProduct}=="ffb0", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffb0", GOTO="adb"
 #   diag,modem,service,mass_storage,adb
-ATTR{idProduct}=="ffb2", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffb2", GOTO="adb"
 #   adb
-ATTR{idProduct}=="ffc1", ENV{adb_adb}="yes"
+ATTR{idProduct}=="ffc1", GOTO="adb"
 #   diag,mass_storage,adb
-ATTR{idProduct}=="ffc0", ENV{adb_adb}="yes"
-GOTO="android_usb_rule_match"
+ATTR{idProduct}=="ffc0", GOTO="adb"
+GOTO="android_usb_rules_end"
 LABEL="not_ZTE"
 
 # ZUK
-ATTR{idVendor}=="2b4c", ENV{adb_user}="yes"
+ATTR{idVendor}=="2b4c", GOTO="user"
 
 # Verifone
-ATTR{idVendor}=="11ca", ENV{adb_user}="yes"
+ATTR{idVendor}=="11ca", GOTO="user"
 
-# Skip other vendor tests
+# No android devices found
+GOTO="android_usb_rules_end"
+
+# ADB Debug User (default)
+LABEL="adb", ENV{adb_adb}="yes", GOTO="android_usb_rule_match"
+
+# ADB Debug and Audio Source
+LABEL="adbaud", ENV{adb_adb}="yes"
+LABEL="aud", ENV{adb_user}="yes", GOTO="android_usb_rule_match"
+
+# ADB Debug and AT-commands CDC Serial
+LABEL="adbcdc", ENV{adb_adb}="yes"
+LABEL="cdc", ENV{adb_user}="yes", GOTO="android_usb_rule_match"
+
+# ADB Debug and Fastboot mode
+LABEL="adbfast", ENV{adb_adbfast}="yes", GOTO="android_usb_rule_match"
+
+# ADB Debug and mass storage (note: android_ver<4.3)
+LABEL="adbmass", ENV{adb_adbmass}="yes"
+LABEL="mass", ENV{adb_mass}="yes", GOTO="android_usb_rule_match"
+
+# ADB Debug and MIDI mode (also check to see /dev/midi%n)
+LABEL="adbmidi", ENV{adb_adbmidi}="yes"
+LABEL="midi", ENV{adb_user}="yes", GOTO="android_usb_rule_match"
+
+# ADB Debug and MTP mode
+LABEL="adbmtp", ENV{adb_adbmtp}="yes"
+LABEL="mtp", ENV{adb_mtp}="yes", GOTO="android_usb_rule_match"
+
+# ADB Debug and PTP mode
+LABEL="adbptp", ENV{adb_adbptp}="yes"
+LABEL="ptp", ENV{adb_ptp}="yes", GOTO="android_usb_rule_match"
+
+# ADB Debug and Tether mode
+LABEL="adbrndis", ENV{adb_adb}="yes"
+LABEL="rndis", ENV{adb_user}="yes", GOTO="android_usb_rule_match"
+
+# Add "android" SYMLINK
+LABEL="user", ENV{adb_user}="yes"
+
+# Symlink common code to reduce steps above
 LABEL="android_usb_rule_match"
-
-# Symlink shortcuts to reduce code in tests above
 ENV{adb_adbfast}=="yes", ENV{adb_adb}="yes", ENV{adb_fast}="yes"
-ENV{adb_adbmtp}=="yes", ENV{adb_adb}="yes", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
-ENV{adb_adbptp}=="yes", ENV{adb_adb}="yes"
-ENV{adb_adbtet}=="yes", ENV{adb_adb}="yes"
-ENV{adb_adbmidi}=="yes", ENV{adb_adb}="yes", SYMLINK+="midi", SYMLINK+="midi0%n"
+ENV{adb_adbmtp}=="yes", ENV{adb_adb}="yes", ENV{adb_mtp}="yes"
+ENV{adb_adbptp}=="yes", ENV{adb_adb}="yes", ENV{adb_ptp}="yes"
+ENV{adb_adbmidi}=="yes", ENV{adb_adb}="yes", SYMLINK+="android_midi", SYMLINK+="android_midi0%n"
 ENV{adb_adb}=="yes", ENV{adb_user}="yes", SYMLINK+="android_adb"
 ENV{adb_fast}=="yes", SYMLINK+="android_fastboot"
+ENV{adb_ptp}=="yes", ENV{adb_user}="yes", ATTR{bDeviceClass}=="00|02|06|ef|ff", ENV{adb_mtp}="yes"
+ENV{adb_mtp}=="yes", ENV{adb_user}="yes", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
 
 # Enable device as a user device if found (add an "android" SYMLINK)
 ENV{adb_user}=="yes", MODE="0660", GROUP="adbusers", TAG+="uaccess", SYMLINK+="android", SYMLINK+="android%n"


### PR DESCRIPTION
This code should run faster than the existing code after a device is found, by using GOTO LABEL (which is basically a string search of text).

The existing code right now (before this patch) may end up doing several more unnecessary value checks while dropping-down through next lines of code.