### PR TITLE
Modify generic adb to be more specific adb GOTOs for Oppo and OnePlus

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -340,6 +340,8 @@ LABEL="not_Intel"
 
 # IUNI
 ATTR{idVendor}!="271d", GOTO="not_IUNI"
+#   Gionee (3f11=mass,adb)
+ATTR{idProduct}=="3f11", GOTO="adbmass"
 #   U3
 ATTR{idProduct}=="bf39", GOTO="adb"
 GOTO="android_usb_rules_end"
@@ -498,16 +500,20 @@ ATTR{idVendor}=="2833", GOTO="user"
 
 # OnePlus(Oreo)
 ATTR{idVendor}!="2a70", GOTO="not_OnePlus"
+#   Oneplus 3T/5T/6 (4ee7=charge,adb)
 #   OnePlus 6, 4ee1=charging, 4ee2=MTP+debug, 4ee6=PTP+debug, 4ee7=charging+debug
-ATTR{idProduct}=="4ee2", GOTO="adb"
-ATTR{idProduct}=="4ee6", GOTO="adb"
+ATTR{idProduct}=="4ee2", GOTO="adbmtp"
+ATTR{idProduct}=="4ee6", GOTO="adbptp"
 ATTR{idProduct}=="4ee7", GOTO="adb"
 #   OnePlus Nord N10 4G USB tethering mode
 ATTR{idProduct}=="9024", GOTO="adb"
-#   OnePlus 3T with Oreo MIDI mode 90bb=adb+midi, 9011=MTP, 904e=PTP
-ATTR{idProduct}=="90bb", GOTO="adb"
-ATTR{idProduct}=="9011", SYMLINK+="android_adb"
-ATTR{idProduct}=="904e", SYMLINK+="android_adb"
+#   OnePlus 3T with Oreo MIDI mode 90bb=midi,adb 9011=mtp 904d=ptp 904e=ptp,adb
+#   OnePlus 7t (9012=mtp,adb)
+ATTR{idProduct}=="9011", GOTO="mtp"
+ATTR{idProduct}=="9012", GOTO="adbmtp"
+ATTR{idProduct}=="904d", GOTO="ptp"
+ATTR{idProduct}=="904e", GOTO="adbptp"
+ATTR{idProduct}=="90bb", GOTO="adbmidi"
 GOTO="android_usb_rule_match"
 LABEL="not_OnePlus"
 
@@ -526,9 +532,11 @@ ATTR{idProduct}=="2024", GOTO="user"
 ATTR{idProduct}=="200e", GOTO="user"
 ATTR{idProduct}=="2028", GOTO="user"
 ATTR{idProduct}=="2026", GOTO="user"
-#   OnePlus 8T (22d9:2771=adb,PTP, 22d9:2772=adb,MTP)
-ATTR{idProduct}=="2771", GOTO="adb"
-ATTR{idProduct}=="2772", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
+#   OnePlus 7a (2774=mass,adb)
+#   OnePlus 8T (2771=adb,ptp 2772=adb,mtp)
+ATTR{idProduct}=="2771", GOTO="adbptp"
+ATTR{idProduct}=="2772", GOTO="adbmtp"
+ATTR{idProduct}=="2774", GOTO="adbmass"
 GOTO="android_usb_rule_match"
 LABEL="not_Oppo"
 
@@ -573,8 +581,8 @@ LABEL="not_Polar"
 ATTR{idVendor}!="05c6", GOTO="not_Qualcomm"
 #   Geeksphone Zero
 ATTR{idProduct}=="9025", SYMLINK+="android_adb"
-#   OnePlus One
-ATTR{idProduct}=="676?", SYMLINK+="android_adb"
+#   OnePlus One (6765=mtp,adb, 6764=mtp)
+ATTR{idProduct}=="6765", GOTO="adbmtp"
 #   OnePlus Two
 ATTR{idProduct}=="9011", SYMLINK+="android_adb"
 #   OnePlus 3


### PR DESCRIPTION
Aligned some codes based on earlier commenting.

included gentoo's 22d9:2774=mass,adb and gionee 271d:3f11=mass,adb:
https://forums.gentoo.org/viewtopic-t-1067416-start-0.html

 Also scraped some idProducts from linux-usb.org which had several references for 3T,5T,6 for idProduct={4ee7,904d,904e}

Also scraped some further idProducts from libmtp:
OnePlus One (6765=mtp,adb, 6764=mtp), issue112=9012=mtb,adb
