### PR TITLE
Add/edit Samsung Core

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -613,8 +613,8 @@ LABEL="not_RIM"
 
 # Samsung
 ATTR{idVendor}!="04e8", GOTO="not_Samsung"
-#   False positive printer
-ATTR{idProduct}=="3???", GOTO="android_usb_rules_end"
+#   False positive printer and other devices
+ATTR{idProduct}!="6???", GOTO="android_usb_rules_end"
 #   Galaxy i5700
 ATTR{idProduct}=="681c", GOTO="adbfast"
 #   Galaxy i5800 (681c=debug,6601=fastboot,68a0=mediaplayer)
@@ -632,13 +632,12 @@ ATTR{idProduct}=="689e", GOTO="adbfast"
 #   Galaxy Tab
 ATTR{idProduct}=="6877", GOTO="adbfast"
 #   Galaxy Nexus (GSM) (6860=mtp,adb 6864=rndis,adb 6866=ptp,adb)
-ATTR{idProduct}=="6860", SYMLINK+="android_adb"
-ATTR{idProduct}=="6864", SYMLINK+="android_adb"
-ATTR{idProduct}=="6866", SYMLINK+="android_adb"
+#   Galaxy Core ([6860=mtp+6860=mtp,adb] 6863=tether 6864=tether,adb 6865=ptp 6866=ptp,adb)
+ATTR{idProduct}=="6860", SYMLINK+="android_adb", GOTO="mtp"
+ATTR{idProduct}=="6864", GOTO="adbrndis"
+ATTR{idProduct}=="6866", GOTO="adbptp"
 #   Galaxy Core, Tab 10.1, i9100 S2, i9300 S3, N5100 Note (8.0), Galaxy S3 SHW-M440S 3G (Korea only)
 ATTR{idProduct}=="685e", GOTO="adbfast"
-#   Galaxy i9300 S3
-ATTR{idProduct}=="6866", SYMLINK+="libmtp-%k", ENV{ID_MTP_DEVICE}="1", ENV{ID_MEDIA_PLAYER}="1"
 #   Galaxy S4 GT-I9500
 ATTR{idProduct}=="685d", SYMLINK+="android_adb"
 ENV{adb_user}="yes"


### PR DESCRIPTION
Enter values as per core phone.
Seeing device hunter webpage, changed false positives to ony pass 6???
```
samsung galaxy core sm-g386w
teher
04e8:6863 Samsung Electronics Co., Ltd Galaxy series, misc. (tethering mode)
dbg,tethering
Bus 001 Device 009: ID 04e8:6864 Samsung Electronics Co., Ltd GT-I9070 (network tethering, USB debugging enabled)

adb,mtp
Bus 001 Device 008: ID 04e8:6860 Samsung Electronics Co., Ltd Galaxy series, misc. (MTP mode)
Bus 001 Device 010: ID 04e8:6860 Samsung Electronics Co., Ltd Galaxy series, misc. (MTP mode)
ptp
Bus 001 Device 010: ID 04e8:6865 Samsung Electronics Co., Ltd Galaxy (PTP mode)
ptp,adb
Bus 001 Device 011: ID 04e8:6866 Samsung Electronics Co., Ltd Galaxy (debugging mode)
```

