### PR TITLE
chore: modify BQ device as adb+mtp, or mtp

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -128,9 +128,8 @@ LABEL="not_Asus"
 
 # BQ
 ATTR{idVendor}!="2a47", GOTO="not_BQ"
-#   Aquaris 4.5
-ATTR{idProduct}=="0c02", GOTO="adbfast"
-ATTR{idProduct}=="2008", GOTO="adbfast"
+#   Aquaris 4.5, Krillin (0c02=mtp,adb 2008=mtp)
+ATTR{idProduct}=="0c02", GOTO="adbmtp"
 GOTO="android_usb_rules_end"
 LABEL="not_BQ"
 
@@ -523,6 +522,7 @@ ATTR{idProduct}=="2eb7", GOTO="mass" # off
 ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Motorola"
+
 # MTK (MediaTek Inc)
 ATTR{idVendor}!="0e8d", GOTO="not_MTK"
 #   Umidigi F1 (201c=adbfast)


### PR DESCRIPTION
initial patch was to add android links, however, based on looking at libmtp these are both mtp, therefore changed these to adb+mtp, while the mtp-only product was dropped and left for libmtp to handle since it appears there is no adb for this. More details given in issue #46