### PR TITLE
feat: Add Google Pixel Watch 2

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -208,6 +208,9 @@ ATTR{idProduct}=="4ee9", GOTO="adbmidi"
 #   Tensor Pixel phones (Pixel 7/7 pro/6/6A/6 Pro) 4eeb=cdc-ncm; 4eec=cdc-ncm,adb
 ATTR{idProduct}=="4eec", GOTO="adbcdc"
 
+#   Pixel Watch 2 (4ee0=fastboot 4e11=adb)
+ATTR{idProduct}=="4e11", GOTO="adb"
+
 #   Pixel C Tablet (5202=mtp 5203=mtp,adb)
 ATTR{idProduct}=="5201", GOTO="adbfast"
 ATTR{idProduct}=="5203", GOTO="adbmtp"


### PR DESCRIPTION
Adb and fastboot tested.

Adb does appear to use the same productId `4e11` as the Nexus One in normal mode (as per code comment).