### PR TITLE
Added Alcatel 5024L

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -827,7 +827,7 @@ ATTR{idProduct}=="00f2", GOTO="adb"
 #   Alcatel OT6012A
 ATTR{idProduct}=="0167", GOTO="adb"
 #   Alcatel 5024L
-ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
+ATTR{idProduct}=="4ee7", GOTO="adb"
 ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_T_A_Mobile"

--- a/51-android.rules
+++ b/51-android.rules
@@ -826,6 +826,8 @@ ATTR{idProduct}=="0c01", GOTO="adb"
 ATTR{idProduct}=="00f2", GOTO="adb"
 #   Alcatel OT6012A
 ATTR{idProduct}=="0167", GOTO="adb"
+#   Alcatel 5024L
+ATTR{idProduct}=="4ee7", ENV{adb_adb}="yes"
 ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_T_A_Mobile"


### PR DESCRIPTION
Add Alcatel 5024L - aka Alcatel 1S - tested on voidlinux and working with scrcpy

Linux achar-void 6.5.13_1 #1 SMP PREEMPT_DYNAMIC Thu Nov 30 23:19:06 UTC 2023 x86_64 GNU/Linux