### PR TITLE
feat: Add fastboot Google Pixel 7

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -219,6 +219,7 @@ ATTR{idProduct}=="4ee9", GOTO="adbmidi"
 
 #   Tensor Pixel phones (Pixel 7/7 pro/6/6A/6 Pro) 4eeb=cdc-ncm; 4eec=cdc-ncm,adb
 ATTR{idProduct}=="4eec", GOTO="adbcdc"
+ATTR{idProduct}=="4ee0", GOTO="adbfast"
 
 #   Pixel Watch 2 (4ee0=fastboot 4e11=adb)
 ATTR{idProduct}=="4e11", GOTO="adb"


### PR DESCRIPTION
With connected Pixel 7 in a fastboot mode, lsusb outputs:

`Bus 001 Device 009: ID 18d1:4ee0 Google Inc. Nexus/Pixel Device (fastboot)`

Tested, works.