### PR TITLE
add Quectel EC25

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -700,6 +700,13 @@ ENV{adb_user}="yes"
 GOTO="android_usb_rule_match"
 LABEL="not_Qualcomm"
 
+# Quectel
+ATTR{idVendor}!="2c7c", GOTO="not_Quectel"
+#   EC25
+ATTR{idProduct}=="0125", GOTO="adb"
+GOTO="android_usb_rules_end"
+LABEL="not_Quectel"
+
 # Razer USA, Ltd.
 ATTR{idVendor}!="1532", GOTO="not_Razer"
 #   Razer Phone 2


### PR DESCRIPTION
with https://github.com/the-modem-distro/pinephone_modem_sdk , it possible to enable adb on this modem (id didnt changed)
```
ID 2c7c:0125 Quectel Wireless Solutions Co., Ltd. EC25 LTE modem
```