### PR TITLE
Add udev rule for Zenfone 8

### DIFF
--- a/51-android.rules
+++ b/51-android.rules
@@ -134,6 +134,10 @@ ATTR{idProduct}=="7781", GOTO="adbmtp"
 ATTR{idProduct}=="4e1f", GOTO="adbmtp"
 #   Tegra APX
 ATTR{idProduct}=="7030", GOTO="adb"
+#   Zenfone 8
+ATTR{idProduct}=="4dae", GOTO="adb"
+ATTR{idProduct}=="4dae", GOTO="adbfast"
+ATTR{idProduct}=="4dae", GOTO="adbmtp"
 GOTO="android_usb_rules_end"
 LABEL="not_Asus"
 


### PR DESCRIPTION
These rules are needed to see devices in sideload mode after calling "adb -d reboot sideload" with the phone attached.

Tested on my Zenfone 8.