### PR TITLE
fix: version the spec

### DIFF
--- a/rpm/android-udev-rules.spec
+++ b/rpm/android-udev-rules.spec
@@ -1,5 +1,5 @@
 Name:           android-udev-rules
-Version:        20230310
+Version:        20241024
 Release:        1%{?dist}
 Summary:        Udev rules to connect Android devices to your linux box
 License:        GPL-3.0-or-later


### PR DESCRIPTION
Without proper spec versioning, package managers can get confused over which build to install, causing inconsistent behavior. The spec should be versioned each time the files are changed.